### PR TITLE
Support for drawing pin electrical types, bug fixes and improvements

### DIFF
--- a/AltiumSharp/BasicTypes/Layer.cs
+++ b/AltiumSharp/BasicTypes/Layer.cs
@@ -2,160 +2,107 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
-using System.Linq;
 
 namespace AltiumSharp.BasicTypes
 {
-    /// <summary>
-    /// Information about the possible layers.
-    /// </summary>
-    internal class LayerMetadata
-    {
-        private static Dictionary<Layer, LayerMetadata> _info = new Dictionary<Layer, LayerMetadata>();
-
-        private static void RegisterLayerInfo(int id, string name, int drawPriority, Color color)
-        {
-            _info.Add((byte)id, new LayerMetadata((byte)id, name, drawPriority, color));
-        }
-
-        static LayerMetadata()
-        {
-            /* from Default.PCBSysColors */
-            RegisterLayerInfo(_info.Count + 1, "TopLayer", 3, ColorTranslator.FromWin32(0x000000FF));
-            RegisterLayerInfo(_info.Count + 1, "MidLayer1", 3, ColorTranslator.FromWin32(0x00008EBC));
-            RegisterLayerInfo(_info.Count + 1, "MidLayer2", 3, ColorTranslator.FromWin32(0x00FADB70));
-            RegisterLayerInfo(_info.Count + 1, "MidLayer3", 3, ColorTranslator.FromWin32(0x0066CC00));
-            RegisterLayerInfo(_info.Count + 1, "MidLayer4", 3, ColorTranslator.FromWin32(0x00FF6699));
-            RegisterLayerInfo(_info.Count + 1, "MidLayer5", 3, ColorTranslator.FromWin32(0x00FFFF00));
-            RegisterLayerInfo(_info.Count + 1, "MidLayer6", 3, ColorTranslator.FromWin32(0x00800080));
-            RegisterLayerInfo(_info.Count + 1, "MidLayer7", 3, ColorTranslator.FromWin32(0x00FF00FF));
-            RegisterLayerInfo(_info.Count + 1, "MidLayer8", 3, ColorTranslator.FromWin32(0x00008080));
-            RegisterLayerInfo(_info.Count + 1, "MidLayer9", 3, ColorTranslator.FromWin32(0x0000FFFF));
-            RegisterLayerInfo(_info.Count + 1, "MidLayer10", 3, ColorTranslator.FromWin32(0x00808080));
-            RegisterLayerInfo(_info.Count + 1, "MidLayer11", 3, ColorTranslator.FromWin32(0x00FFFFFF));
-            RegisterLayerInfo(_info.Count + 1, "MidLayer12", 3, ColorTranslator.FromWin32(0x00800080));
-            RegisterLayerInfo(_info.Count + 1, "MidLayer13", 3, ColorTranslator.FromWin32(0x00808000));
-            RegisterLayerInfo(_info.Count + 1, "MidLayer14", 3, ColorTranslator.FromWin32(0x00C0C0C0));
-            RegisterLayerInfo(_info.Count + 1, "MidLayer15", 3, ColorTranslator.FromWin32(0x00000080));
-            RegisterLayerInfo(_info.Count + 1, "MidLayer16", 3, ColorTranslator.FromWin32(0x00008000));
-            RegisterLayerInfo(_info.Count + 1, "MidLayer17", 3, ColorTranslator.FromWin32(0x0000FF00));
-            RegisterLayerInfo(_info.Count + 1, "MidLayer18", 3, ColorTranslator.FromWin32(0x00800000));
-            RegisterLayerInfo(_info.Count + 1, "MidLayer19", 3, ColorTranslator.FromWin32(0x00FFFF00));
-            RegisterLayerInfo(_info.Count + 1, "MidLayer20", 3, ColorTranslator.FromWin32(0x00800080));
-            RegisterLayerInfo(_info.Count + 1, "MidLayer21", 3, ColorTranslator.FromWin32(0x00FF00FF));
-            RegisterLayerInfo(_info.Count + 1, "MidLayer22", 3, ColorTranslator.FromWin32(0x00008080));
-            RegisterLayerInfo(_info.Count + 1, "MidLayer23", 3, ColorTranslator.FromWin32(0x0000FFFF));
-            RegisterLayerInfo(_info.Count + 1, "MidLayer24", 3, ColorTranslator.FromWin32(0x00808080));
-            RegisterLayerInfo(_info.Count + 1, "MidLayer25", 3, ColorTranslator.FromWin32(0x00FFFFFF));
-            RegisterLayerInfo(_info.Count + 1, "MidLayer26", 3, ColorTranslator.FromWin32(0x00800080));
-            RegisterLayerInfo(_info.Count + 1, "MidLayer27", 3, ColorTranslator.FromWin32(0x00808000));
-            RegisterLayerInfo(_info.Count + 1, "MidLayer28", 3, ColorTranslator.FromWin32(0x00C0C0C0));
-            RegisterLayerInfo(_info.Count + 1, "MidLayer29", 3, ColorTranslator.FromWin32(0x00000080));
-            RegisterLayerInfo(_info.Count + 1, "MidLayer30", 3, ColorTranslator.FromWin32(0x00008000));
-            RegisterLayerInfo(_info.Count + 1, "BottomLayer", 2, ColorTranslator.FromWin32(0x00FF0000));
-            RegisterLayerInfo(_info.Count + 1, "TopOverlay", 2, ColorTranslator.FromWin32(0x0000FFFF));
-            RegisterLayerInfo(_info.Count + 1, "BottomOverlay", 2, ColorTranslator.FromWin32(0x00008080));
-            RegisterLayerInfo(_info.Count + 1, "TopPaste", 2, ColorTranslator.FromWin32(0x00808080));
-            RegisterLayerInfo(_info.Count + 1, "BottomPaste", 2, ColorTranslator.FromWin32(0x00000080));
-            RegisterLayerInfo(_info.Count + 1, "TopSolder", 2, ColorTranslator.FromWin32(0x00800080));
-            RegisterLayerInfo(_info.Count + 1, "BottomSolder", 2, ColorTranslator.FromWin32(0x00FF00FF));
-            RegisterLayerInfo(_info.Count + 1, "InternalPlane1", 3, ColorTranslator.FromWin32(0x00008000));
-            RegisterLayerInfo(_info.Count + 1, "InternalPlane2", 3, ColorTranslator.FromWin32(0x00000080));
-            RegisterLayerInfo(_info.Count + 1, "InternalPlane3", 3, ColorTranslator.FromWin32(0x00800080));
-            RegisterLayerInfo(_info.Count + 1, "InternalPlane4", 3, ColorTranslator.FromWin32(0x00808000));
-            RegisterLayerInfo(_info.Count + 1, "InternalPlane5", 3, ColorTranslator.FromWin32(0x00008000));
-            RegisterLayerInfo(_info.Count + 1, "InternalPlane6", 3, ColorTranslator.FromWin32(0x00000080));
-            RegisterLayerInfo(_info.Count + 1, "InternalPlane7", 3, ColorTranslator.FromWin32(0x00800080));
-            RegisterLayerInfo(_info.Count + 1, "InternalPlane8", 3, ColorTranslator.FromWin32(0x00808000));
-            RegisterLayerInfo(_info.Count + 1, "InternalPlane9", 3, ColorTranslator.FromWin32(0x00008000));
-            RegisterLayerInfo(_info.Count + 1, "InternalPlane10", 3, ColorTranslator.FromWin32(0x00000080));
-            RegisterLayerInfo(_info.Count + 1, "InternalPlane11", 3, ColorTranslator.FromWin32(0x00800080));
-            RegisterLayerInfo(_info.Count + 1, "InternalPlane12", 3, ColorTranslator.FromWin32(0x00808000));
-            RegisterLayerInfo(_info.Count + 1, "InternalPlane13", 3, ColorTranslator.FromWin32(0x00008000));
-            RegisterLayerInfo(_info.Count + 1, "InternalPlane14", 3, ColorTranslator.FromWin32(0x00000080));
-            RegisterLayerInfo(_info.Count + 1, "InternalPlane15", 3, ColorTranslator.FromWin32(0x00800080));
-            RegisterLayerInfo(_info.Count + 1, "InternalPlane16", 3, ColorTranslator.FromWin32(0x00808000));
-            RegisterLayerInfo(_info.Count + 1, "DrillGuide", 2, ColorTranslator.FromWin32(0x00000080));
-            RegisterLayerInfo(_info.Count + 1, "KeepOutLayer", 3, ColorTranslator.FromWin32(0x00FF00FF));
-            RegisterLayerInfo(_info.Count + 1, "Mechanical1", 3, ColorTranslator.FromWin32(0x00FF00FF));
-            RegisterLayerInfo(_info.Count + 1, "Mechanical2", 3, ColorTranslator.FromWin32(0x00800080));
-            RegisterLayerInfo(_info.Count + 1, "Mechanical3", 3, ColorTranslator.FromWin32(0x00008000));
-            RegisterLayerInfo(_info.Count + 1, "Mechanical4", 3, ColorTranslator.FromWin32(0x00008080));
-            RegisterLayerInfo(_info.Count + 1, "Mechanical5", 3, ColorTranslator.FromWin32(0x00FF00FF));
-            RegisterLayerInfo(_info.Count + 1, "Mechanical6", 3, ColorTranslator.FromWin32(0x00800080));
-            RegisterLayerInfo(_info.Count + 1, "Mechanical7", 3, ColorTranslator.FromWin32(0x00008000));
-            RegisterLayerInfo(_info.Count + 1, "Mechanical8", 3, ColorTranslator.FromWin32(0x00008080));
-            RegisterLayerInfo(_info.Count + 1, "Mechanical9", 3, ColorTranslator.FromWin32(0x00FF00FF));
-            RegisterLayerInfo(_info.Count + 1, "Mechanical10", 3, ColorTranslator.FromWin32(0x00800080));
-            RegisterLayerInfo(_info.Count + 1, "Mechanical11", 3, ColorTranslator.FromWin32(0x00008000));
-            RegisterLayerInfo(_info.Count + 1, "Mechanical12", 3, ColorTranslator.FromWin32(0x00008080));
-            RegisterLayerInfo(_info.Count + 1, "Mechanical13", 3, ColorTranslator.FromWin32(0x00FF00FF));
-            RegisterLayerInfo(_info.Count + 1, "Mechanical14", 3, ColorTranslator.FromWin32(0x00800080));
-            RegisterLayerInfo(_info.Count + 1, "Mechanical15", 3, ColorTranslator.FromWin32(0x00008000));
-            RegisterLayerInfo(_info.Count + 1, "Mechanical16", 3, ColorTranslator.FromWin32(0x00000000));
-            RegisterLayerInfo(_info.Count + 1, "DrillDrawing", 3, ColorTranslator.FromWin32(0x002A00FF));
-            RegisterLayerInfo(_info.Count + 1, "MultiLayer", 1, ColorTranslator.FromWin32(0x00C0C0C0));
-            RegisterLayerInfo(_info.Count + 1, "ConnectLayer", 2, ColorTranslator.FromWin32(0x0075A19E));
-            RegisterLayerInfo(_info.Count + 1, "BackGroundLayer", 5, ColorTranslator.FromWin32(0x00000000));
-            RegisterLayerInfo(_info.Count + 1, "DRCErrorLayer", 3, ColorTranslator.FromWin32(0x0000FF00));
-            RegisterLayerInfo(_info.Count + 1, "HighlightLayer", 0, ColorTranslator.FromWin32(0x00FFFFFF));
-            RegisterLayerInfo(_info.Count + 1, "GridColor1", 5, ColorTranslator.FromWin32(0x005C4D4D));
-            RegisterLayerInfo(_info.Count + 1, "GridColor10", 5, ColorTranslator.FromWin32(0x00908D91));
-            RegisterLayerInfo(_info.Count + 1, "PadHoleLayer", 2, ColorTranslator.FromWin32(0x00909100));
-            RegisterLayerInfo(_info.Count + 1, "ViaHoleLayer", 2, ColorTranslator.FromWin32(0x00006281));
-        }
-
-        public static LayerMetadata Get(Layer layer) =>
-            _info.TryGetValue(layer, out var result) ? result : null;
-
-        public static LayerMetadata Get(string layerName) =>
-            _info.Values.FirstOrDefault(li => layerName.Equals(li.Name, StringComparison.InvariantCultureIgnoreCase));
-
-        public static string GetName(Layer layer) =>
-            Get(layer)?.Name ?? $"UnknownLayer{layer.ToByte()}";
-
-        public static Color GetColor(Layer layer) =>
-            Get(layer)?.Color ?? Color.Empty;
-
-        public static Color GetColor(string layerName) =>
-            Get(layerName)?.Color ?? Color.Empty;
-
-        /// <summary>
-        /// Layer identifier as a byte.
-        /// </summary>
-        public byte Id { get; }
-
-        /// <summary>
-        /// Layer internal name.
-        /// </summary>
-        public string Name { get; }
-
-        /// <summary>
-        /// Layer draw priority. the lower, the higher priority.
-        /// </summary>
-        public int DrawPriority { get; }
-
-        /// <summary>
-        /// Color for the layer.
-        /// </summary>
-        public Color Color { get; }
-
-        private LayerMetadata(byte id, string name, int drawPriority, Color color)
-        {
-            Id = id;
-            Name = name;
-            DrawPriority = drawPriority;
-            Color = color;
-        }
-    }
-
-
     /// <summary>
     /// Layer data type used for ease of handling PCB layer references.
     /// </summary>
     [DebuggerDisplay("{Name,nq}")]
     public readonly struct Layer : IEquatable<Layer>, IComparable<Layer>
     {
+        public static Layer NoLayer = 0;
+        public static Layer TopLayer = 1;
+        public static Layer MidLayer1 = 2;
+        public static Layer MidLayer2 = 3;
+        public static Layer MidLayer3 = 4;
+        public static Layer MidLayer4 = 5;
+        public static Layer MidLayer5 = 6;
+        public static Layer MidLayer6 = 7;
+        public static Layer MidLayer7 = 8;
+        public static Layer MidLayer8 = 9;
+        public static Layer MidLayer9 = 10;
+        public static Layer MidLayer10 = 11;
+        public static Layer MidLayer11 = 12;
+        public static Layer MidLayer12 = 13;
+        public static Layer MidLayer13 = 14;
+        public static Layer MidLayer14 = 15;
+        public static Layer MidLayer15 = 16;
+        public static Layer MidLayer16 = 17;
+        public static Layer MidLayer17 = 18;
+        public static Layer MidLayer18 = 19;
+        public static Layer MidLayer19 = 20;
+        public static Layer MidLayer20 = 21;
+        public static Layer MidLayer21 = 22;
+        public static Layer MidLayer22 = 23;
+        public static Layer MidLayer23 = 24;
+        public static Layer MidLayer24 = 25;
+        public static Layer MidLayer25 = 26;
+        public static Layer MidLayer26 = 27;
+        public static Layer MidLayer27 = 28;
+        public static Layer MidLayer28 = 29;
+        public static Layer MidLayer29 = 30;
+        public static Layer MidLayer30 = 31;
+        public static Layer BottomLayer = 32;
+        public static Layer TopOverlay = 33;
+        public static Layer BottomOverlay = 34;
+        public static Layer TopPaste = 35;
+        public static Layer BottomPaste = 36;
+        public static Layer TopSolder = 37;
+        public static Layer BottomSolder = 38;
+        public static Layer InternalPlane1 = 39;
+        public static Layer InternalPlane2 = 40;
+        public static Layer InternalPlane3 = 41;
+        public static Layer InternalPlane4 = 42;
+        public static Layer InternalPlane5 = 43;
+        public static Layer InternalPlane6 = 44;
+        public static Layer InternalPlane7 = 45;
+        public static Layer InternalPlane8 = 46;
+        public static Layer InternalPlane9 = 47;
+        public static Layer InternalPlane10 = 48;
+        public static Layer InternalPlane11 = 49;
+        public static Layer InternalPlane12 = 50;
+        public static Layer InternalPlane13 = 51;
+        public static Layer InternalPlane14 = 52;
+        public static Layer InternalPlane15 = 53;
+        public static Layer InternalPlane16 = 54;
+        public static Layer DrillGuide = 55;
+        public static Layer KeepOutLayer = 56;
+        public static Layer Mechanical1 = 57;
+        public static Layer Mechanical2 = 58;
+        public static Layer Mechanical3 = 59;
+        public static Layer Mechanical4 = 60;
+        public static Layer Mechanical5 = 61;
+        public static Layer Mechanical6 = 62;
+        public static Layer Mechanical7 = 63;
+        public static Layer Mechanical8 = 64;
+        public static Layer Mechanical9 = 65;
+        public static Layer Mechanical10 = 66;
+        public static Layer Mechanical11 = 67;
+        public static Layer Mechanical12 = 68;
+        public static Layer Mechanical13 = 69;
+        public static Layer Mechanical14 = 70;
+        public static Layer Mechanical15 = 71;
+        public static Layer Mechanical16 = 72;
+        public static Layer DrillDrawing = 73;
+        public static Layer MultiLayer = 74;
+        public static Layer ConnectLayer = 75;
+        public static Layer BackGroundLayer = 76;
+        public static Layer DRCErrorLayer = 77;
+        public static Layer HighlightLayer = 78;
+        public static Layer GridColor1 = 79;
+        public static Layer GridColor10 = 80;
+        public static Layer PadHoleLayer = 81;
+        public static Layer ViaHoleLayer = 82;
+
+        public static Layer TopPadMaster = 83;
+        public static Layer BottomPadMaster = 84;
+        public static Layer DRCDetailLayer = 85;
+        public static Layer Unknown = byte.MaxValue;
+
+        public static IEnumerable<string> Names => LayerMetadata.Names;
+        public static IEnumerable<Layer> Values => LayerMetadata.Values;
+
         private readonly byte _value;
         public Layer(byte value) => _value = value;
         public byte ToByte() => _value;
@@ -165,7 +112,22 @@ namespace AltiumSharp.BasicTypes
         /// <summary>
         /// Gets the internal name of a PCB layer.
         /// </summary>
-        public string Name => Metadata?.Name ?? "Unknown";
+        public string Name => Metadata?.InternalName ?? nameof(Unknown);
+
+        /// <summary>
+        /// Gets the long name of a PCB layer.
+        /// </summary>
+        public string LongName => Metadata?.LongName ?? nameof(Unknown);
+
+        /// <summary>
+        /// Gets the medium name of a PCB layer.
+        /// </summary>
+        public string MediumName => Metadata?.MediumName ?? nameof(Unknown);
+
+        /// <summary>
+        /// Gets the short name of a PCB layer.
+        /// </summary>
+        public string ShortName => Metadata?.ShortName ?? nameof(Unknown);
 
         /// <summary>
         /// Gets the color to be used for this PCB layer.
@@ -179,6 +141,13 @@ namespace AltiumSharp.BasicTypes
         /// </para>
         /// </summary>
         public int DrawPriority => Metadata?.DrawPriority ?? 0;
+
+        /// <summary>
+        /// Creates a layer reference from an internal layer name.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        public static Layer FromString(string layerName) => LayerMetadata.Get(layerName)?.Id ?? Unknown;
 
         public override string ToString() => Name;
 

--- a/AltiumSharp/BasicTypes/LayerMetadata.cs
+++ b/AltiumSharp/BasicTypes/LayerMetadata.cs
@@ -1,0 +1,530 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+
+namespace AltiumSharp.BasicTypes
+{
+    /// <summary>
+    /// Information about the possible layers.
+    /// </summary>
+    internal class LayerMetadata
+    {
+        private static Dictionary<Layer, LayerMetadata> _info = new Dictionary<Layer, LayerMetadata>();
+
+        private static void RegisterLayerInfo(Layer layer, int drawPriority, Color color)
+        {
+            _info.Add(layer, new LayerMetadata(layer, drawPriority, color));
+        }
+
+        public static string[] InternalNames = new string[86]
+        {
+            nameof(Layer.NoLayer),
+            nameof(Layer.TopLayer),
+            nameof(Layer.MidLayer1),
+            nameof(Layer.MidLayer2),
+            nameof(Layer.MidLayer3),
+            nameof(Layer.MidLayer4),
+            nameof(Layer.MidLayer5),
+            nameof(Layer.MidLayer6),
+            nameof(Layer.MidLayer7),
+            nameof(Layer.MidLayer8),
+            nameof(Layer.MidLayer9),
+            nameof(Layer.MidLayer10),
+            nameof(Layer.MidLayer11),
+            nameof(Layer.MidLayer12),
+            nameof(Layer.MidLayer13),
+            nameof(Layer.MidLayer14),
+            nameof(Layer.MidLayer15),
+            nameof(Layer.MidLayer16),
+            nameof(Layer.MidLayer17),
+            nameof(Layer.MidLayer18),
+            nameof(Layer.MidLayer19),
+            nameof(Layer.MidLayer20),
+            nameof(Layer.MidLayer21),
+            nameof(Layer.MidLayer22),
+            nameof(Layer.MidLayer23),
+            nameof(Layer.MidLayer24),
+            nameof(Layer.MidLayer25),
+            nameof(Layer.MidLayer26),
+            nameof(Layer.MidLayer27),
+            nameof(Layer.MidLayer28),
+            nameof(Layer.MidLayer29),
+            nameof(Layer.MidLayer30),
+            nameof(Layer.BottomLayer),
+            nameof(Layer.TopOverlay),
+            nameof(Layer.BottomOverlay),
+            nameof(Layer.TopPaste),
+            nameof(Layer.BottomPaste),
+            nameof(Layer.TopSolder),
+            nameof(Layer.BottomSolder),
+            nameof(Layer.InternalPlane1),
+            nameof(Layer.InternalPlane2),
+            nameof(Layer.InternalPlane3),
+            nameof(Layer.InternalPlane4),
+            nameof(Layer.InternalPlane5),
+            nameof(Layer.InternalPlane6),
+            nameof(Layer.InternalPlane7),
+            nameof(Layer.InternalPlane8),
+            nameof(Layer.InternalPlane9),
+            nameof(Layer.InternalPlane10),
+            nameof(Layer.InternalPlane11),
+            nameof(Layer.InternalPlane12),
+            nameof(Layer.InternalPlane13),
+            nameof(Layer.InternalPlane14),
+            nameof(Layer.InternalPlane15),
+            nameof(Layer.InternalPlane16),
+            nameof(Layer.DrillGuide),
+            nameof(Layer.KeepOutLayer),
+            nameof(Layer.Mechanical1),
+            nameof(Layer.Mechanical2),
+            nameof(Layer.Mechanical3),
+            nameof(Layer.Mechanical4),
+            nameof(Layer.Mechanical5),
+            nameof(Layer.Mechanical6),
+            nameof(Layer.Mechanical7),
+            nameof(Layer.Mechanical8),
+            nameof(Layer.Mechanical9),
+            nameof(Layer.Mechanical10),
+            nameof(Layer.Mechanical11),
+            nameof(Layer.Mechanical12),
+            nameof(Layer.Mechanical13),
+            nameof(Layer.Mechanical14),
+            nameof(Layer.Mechanical15),
+            nameof(Layer.Mechanical16),
+            nameof(Layer.DrillDrawing),
+            nameof(Layer.MultiLayer),
+            nameof(Layer.ConnectLayer),
+            nameof(Layer.BackGroundLayer),
+            nameof(Layer.DRCErrorLayer),
+            nameof(Layer.HighlightLayer),
+            nameof(Layer.GridColor1),
+            nameof(Layer.GridColor10),
+            nameof(Layer.PadHoleLayer),
+            nameof(Layer.ViaHoleLayer),
+
+            nameof(Layer.TopPadMaster),
+            nameof(Layer.BottomPadMaster),
+            nameof(Layer.DRCDetailLayer)
+        };
+
+        public static string[] ShortNames = new string[86]
+        {
+            "NoLayer",
+            "TL",
+            "M1",
+            "M2",
+            "M3",
+            "M4",
+            "M5",
+            "M6",
+            "M7",
+            "M8",
+            "M9",
+            "M10",
+            "M11",
+            "M12",
+            "M13",
+            "M14",
+            "M15",
+            "M16",
+            "M17",
+            "M18",
+            "M19",
+            "M20",
+            "M21",
+            "M22",
+            "M23",
+            "M24",
+            "M25",
+            "M26",
+            "M27",
+            "M28",
+            "M29",
+            "M30",
+            "BL",
+            "TO",
+            "BO",
+            "TP",
+            "BP",
+            "TS",
+            "BS",
+            "P1",
+            "P2",
+            "P3",
+            "P4",
+            "P5",
+            "P6",
+            "P7",
+            "P8",
+            "P9",
+            "P10",
+            "P11",
+            "P12",
+            "P13",
+            "P14",
+            "P15",
+            "P16",
+            "DG",
+            "KO",
+            "M1",
+            "M2",
+            "M3",
+            "M4",
+            "M5",
+            "M6",
+            "M7",
+            "M8",
+            "M9",
+            "M10",
+            "M11",
+            "M12",
+            "M13",
+            "M14",
+            "M15",
+            "M16",
+            "DD",
+            "ML",
+            "CL",
+            "BR",
+            "DRC",
+            "HL",
+            "GC1",
+            "GC2",
+            "PH",
+            "VH",
+
+            "TM",
+            "BM",
+            "DRCD"
+        };
+
+        public static string[] MediumNames = new string[86]
+        {
+            "NoLayer",
+            "Top",
+            "Mid-1",
+            "Mid-2",
+            "Mid-3",
+            "Mid-4",
+            "Mid-5",
+            "Mid-6",
+            "Mid-7",
+            "Mid-8",
+            "Mid-9",
+            "Mid-10",
+            "Mid-11",
+            "Mid-12",
+            "Mid-13",
+            "Mid-14",
+            "Mid-15",
+            "Mid-16",
+            "Mid-17",
+            "Mid-18",
+            "Mid-19",
+            "Mid-20",
+            "Mid-21",
+            "Mid-22",
+            "Mid-23",
+            "Mid-24",
+            "Mid-25",
+            "Mid-26",
+            "Mid-27",
+            "Mid-28",
+            "Mid-29",
+            "Mid-30",
+            "Bottom",
+            "T-Silk",
+            "B-Silk",
+            "T-Paste",
+            "B-Paste",
+            "T-Solder",
+            "B-Solder",
+            "Plane-1",
+            "Plane-2",
+            "Plane-3",
+            "Plane-4",
+            "Plane-5",
+            "Plane-6",
+            "Plane-7",
+            "Plane-8",
+            "Plane-9",
+            "Plane-10",
+            "Plane-11",
+            "Plane-12",
+            "Plane-13",
+            "Plane-14",
+            "Plane-15",
+            "Plane-16",
+            "D-Guide",
+            "KeepOut",
+            "Mech-1",
+            "Mech-2",
+            "Mech-3",
+            "Mech-4",
+            "Mech-5",
+            "Mech-6",
+            "Mech-7",
+            "Mech-8",
+            "Mech-9",
+            "Mech-10",
+            "Mech-11",
+            "Mech-12",
+            "Mech-13",
+            "Mech-14",
+            "Mech-15",
+            "Mech-16",
+            "D-Draw",
+            "Multi",
+            "CL",
+            "BR",
+            "DRC",
+            "Highlight",
+            "Grid1",
+            "Grid2",
+            "PadHole",
+            "ViaHole",
+
+            "TPMaster",
+            "BPMaster",
+            "DRC Detail"
+        };
+
+        public static string[] LongNames = new string[86]
+        {
+            "NoLayer",
+            "Top Layer",
+            "Mid-Layer 1",
+            "Mid-Layer 2",
+            "Mid-Layer 3",
+            "Mid-Layer 4",
+            "Mid-Layer 5",
+            "Mid-Layer 6",
+            "Mid-Layer 7",
+            "Mid-Layer 8",
+            "Mid-Layer 9",
+            "Mid-Layer 10",
+            "Mid-Layer 11",
+            "Mid-Layer 12",
+            "Mid-Layer 13",
+            "Mid-Layer 14",
+            "Mid-Layer 15",
+            "Mid-Layer 16",
+            "Mid-Layer 17",
+            "Mid-Layer 18",
+            "Mid-Layer 19",
+            "Mid-Layer 20",
+            "Mid-Layer 21",
+            "Mid-Layer 22",
+            "Mid-Layer 23",
+            "Mid-Layer 24",
+            "Mid-Layer 25",
+            "Mid-Layer 26",
+            "Mid-Layer 27",
+            "Mid-Layer 28",
+            "Mid-Layer 29",
+            "Mid-Layer 30",
+            "Bottom Layer",
+            "Top Overlay",
+            "Bottom Overlay",
+            "Top Paste",
+            "Bottom Paste",
+            "Top Solder",
+            "Bottom Solder",
+            "Internal Plane 1",
+            "Internal Plane 2",
+            "Internal Plane 3",
+            "Internal Plane 4",
+            "Internal Plane 5",
+            "Internal Plane 6",
+            "Internal Plane 7",
+            "Internal Plane 8",
+            "Internal Plane 9",
+            "Internal Plane 10",
+            "Internal Plane 11",
+            "Internal Plane 12",
+            "Internal Plane 13",
+            "Internal Plane 14",
+            "Internal Plane 15",
+            "Internal Plane 16",
+            "Drill Guide",
+            "Keep-Out Layer",
+            "Mechanical 1",
+            "Mechanical 2",
+            "Mechanical 3",
+            "Mechanical 4",
+            "Mechanical 5",
+            "Mechanical 6",
+            "Mechanical 7",
+            "Mechanical 8",
+            "Mechanical 9",
+            "Mechanical 10",
+            "Mechanical 11",
+            "Mechanical 12",
+            "Mechanical 13",
+            "Mechanical 14",
+            "Mechanical 15",
+            "Mechanical 16",
+            "Drill Drawing",
+            "Multi-Layer",
+            "Connections",
+            "Background",
+            "DRC Error Markers",
+            "Selections",
+            "Visible Grid 1",
+            "Visible Grid 2",
+            "Pad Holes",
+            "Via Holes",
+
+            "Top Pad Master",
+            "Bottom Pad Master",
+            "DRC Detail Markers"
+        };
+
+        static LayerMetadata()
+        {
+            RegisterLayerInfo(Layer.NoLayer, 0, Color.Empty);
+            RegisterLayerInfo(Layer.TopLayer, 6, ColorTranslator.FromWin32(0x000000FF));
+            RegisterLayerInfo(Layer.MidLayer1, 6, ColorTranslator.FromWin32(0x00008EBC));
+            RegisterLayerInfo(Layer.MidLayer2, 6, ColorTranslator.FromWin32(0x00FADB70));
+            RegisterLayerInfo(Layer.MidLayer3, 6, ColorTranslator.FromWin32(0x0066CC00));
+            RegisterLayerInfo(Layer.MidLayer4, 6, ColorTranslator.FromWin32(0x00FF6699));
+            RegisterLayerInfo(Layer.MidLayer5, 6, ColorTranslator.FromWin32(0x00FFFF00));
+            RegisterLayerInfo(Layer.MidLayer6, 6, ColorTranslator.FromWin32(0x00800080));
+            RegisterLayerInfo(Layer.MidLayer7, 6, ColorTranslator.FromWin32(0x00FF00FF));
+            RegisterLayerInfo(Layer.MidLayer8, 6, ColorTranslator.FromWin32(0x00008080));
+            RegisterLayerInfo(Layer.MidLayer9, 6, ColorTranslator.FromWin32(0x0000FFFF));
+            RegisterLayerInfo(Layer.MidLayer10, 6, ColorTranslator.FromWin32(0x00808080));
+            RegisterLayerInfo(Layer.MidLayer11, 6, ColorTranslator.FromWin32(0x00FFFFFF));
+            RegisterLayerInfo(Layer.MidLayer12, 6, ColorTranslator.FromWin32(0x00800080));
+            RegisterLayerInfo(Layer.MidLayer13, 6, ColorTranslator.FromWin32(0x00808000));
+            RegisterLayerInfo(Layer.MidLayer14, 6, ColorTranslator.FromWin32(0x00C0C0C0));
+            RegisterLayerInfo(Layer.MidLayer15, 6, ColorTranslator.FromWin32(0x00000080));
+            RegisterLayerInfo(Layer.MidLayer16, 6, ColorTranslator.FromWin32(0x00008000));
+            RegisterLayerInfo(Layer.MidLayer17, 6, ColorTranslator.FromWin32(0x0000FF00));
+            RegisterLayerInfo(Layer.MidLayer18, 6, ColorTranslator.FromWin32(0x00800000));
+            RegisterLayerInfo(Layer.MidLayer19, 6, ColorTranslator.FromWin32(0x00FFFF00));
+            RegisterLayerInfo(Layer.MidLayer20, 6, ColorTranslator.FromWin32(0x00800080));
+            RegisterLayerInfo(Layer.MidLayer21, 6, ColorTranslator.FromWin32(0x00FF00FF));
+            RegisterLayerInfo(Layer.MidLayer22, 6, ColorTranslator.FromWin32(0x00008080));
+            RegisterLayerInfo(Layer.MidLayer23, 6, ColorTranslator.FromWin32(0x0000FFFF));
+            RegisterLayerInfo(Layer.MidLayer24, 6, ColorTranslator.FromWin32(0x00808080));
+            RegisterLayerInfo(Layer.MidLayer25, 6, ColorTranslator.FromWin32(0x00FFFFFF));
+            RegisterLayerInfo(Layer.MidLayer26, 6, ColorTranslator.FromWin32(0x00800080));
+            RegisterLayerInfo(Layer.MidLayer27, 6, ColorTranslator.FromWin32(0x00808000));
+            RegisterLayerInfo(Layer.MidLayer28, 6, ColorTranslator.FromWin32(0x00C0C0C0));
+            RegisterLayerInfo(Layer.MidLayer29, 6, ColorTranslator.FromWin32(0x00000080));
+            RegisterLayerInfo(Layer.MidLayer30, 6, ColorTranslator.FromWin32(0x00008000));
+            RegisterLayerInfo(Layer.BottomLayer, 6, ColorTranslator.FromWin32(0x00FF0000));
+            RegisterLayerInfo(Layer.TopOverlay, 2, ColorTranslator.FromWin32(0x0000FFFF));
+            RegisterLayerInfo(Layer.BottomOverlay, 3, ColorTranslator.FromWin32(0x00008080));
+            RegisterLayerInfo(Layer.TopPaste, 7, ColorTranslator.FromWin32(0x00808080));
+            RegisterLayerInfo(Layer.BottomPaste, 8, ColorTranslator.FromWin32(0x00000080));
+            RegisterLayerInfo(Layer.TopSolder, 9, ColorTranslator.FromWin32(0x00800080));
+            RegisterLayerInfo(Layer.BottomSolder, 10, ColorTranslator.FromWin32(0x00FF00FF));
+            RegisterLayerInfo(Layer.InternalPlane1, 11, ColorTranslator.FromWin32(0x00008000));
+            RegisterLayerInfo(Layer.InternalPlane2, 11, ColorTranslator.FromWin32(0x00000080));
+            RegisterLayerInfo(Layer.InternalPlane3, 11, ColorTranslator.FromWin32(0x00800080));
+            RegisterLayerInfo(Layer.InternalPlane4, 11, ColorTranslator.FromWin32(0x00808000));
+            RegisterLayerInfo(Layer.InternalPlane5, 11, ColorTranslator.FromWin32(0x00008000));
+            RegisterLayerInfo(Layer.InternalPlane6, 11, ColorTranslator.FromWin32(0x00000080));
+            RegisterLayerInfo(Layer.InternalPlane7, 11, ColorTranslator.FromWin32(0x00800080));
+            RegisterLayerInfo(Layer.InternalPlane8, 11, ColorTranslator.FromWin32(0x00808000));
+            RegisterLayerInfo(Layer.InternalPlane9, 11, ColorTranslator.FromWin32(0x00008000));
+            RegisterLayerInfo(Layer.InternalPlane10, 11, ColorTranslator.FromWin32(0x00000080));
+            RegisterLayerInfo(Layer.InternalPlane11, 11, ColorTranslator.FromWin32(0x00800080));
+            RegisterLayerInfo(Layer.InternalPlane12, 11, ColorTranslator.FromWin32(0x00808000));
+            RegisterLayerInfo(Layer.InternalPlane13, 11, ColorTranslator.FromWin32(0x00008000));
+            RegisterLayerInfo(Layer.InternalPlane14, 11, ColorTranslator.FromWin32(0x00000080));
+            RegisterLayerInfo(Layer.InternalPlane15, 11, ColorTranslator.FromWin32(0x00800080));
+            RegisterLayerInfo(Layer.InternalPlane16, 11, ColorTranslator.FromWin32(0x00808000));
+            RegisterLayerInfo(Layer.DrillGuide, 12, ColorTranslator.FromWin32(0x00000080));
+            RegisterLayerInfo(Layer.KeepOutLayer, 13, ColorTranslator.FromWin32(0x00FF00FF));
+            RegisterLayerInfo(Layer.Mechanical1, 14, ColorTranslator.FromWin32(0x00FF00FF));
+            RegisterLayerInfo(Layer.Mechanical2, 14, ColorTranslator.FromWin32(0x00800080));
+            RegisterLayerInfo(Layer.Mechanical3, 14, ColorTranslator.FromWin32(0x00008000));
+            RegisterLayerInfo(Layer.Mechanical4, 14, ColorTranslator.FromWin32(0x00008080));
+            RegisterLayerInfo(Layer.Mechanical5, 14, ColorTranslator.FromWin32(0x00FF00FF));
+            RegisterLayerInfo(Layer.Mechanical6, 14, ColorTranslator.FromWin32(0x00800080));
+            RegisterLayerInfo(Layer.Mechanical7, 14, ColorTranslator.FromWin32(0x00008000));
+            RegisterLayerInfo(Layer.Mechanical8, 14, ColorTranslator.FromWin32(0x00008080));
+            RegisterLayerInfo(Layer.Mechanical9, 14, ColorTranslator.FromWin32(0x00FF00FF));
+            RegisterLayerInfo(Layer.Mechanical10, 14, ColorTranslator.FromWin32(0x00800080));
+            RegisterLayerInfo(Layer.Mechanical11, 14, ColorTranslator.FromWin32(0x00008000));
+            RegisterLayerInfo(Layer.Mechanical12, 14, ColorTranslator.FromWin32(0x00008080));
+            RegisterLayerInfo(Layer.Mechanical13, 14, ColorTranslator.FromWin32(0x00FF00FF));
+            RegisterLayerInfo(Layer.Mechanical14, 14, ColorTranslator.FromWin32(0x00800080));
+            RegisterLayerInfo(Layer.Mechanical15, 14, ColorTranslator.FromWin32(0x00008000));
+            RegisterLayerInfo(Layer.Mechanical16, 14, ColorTranslator.FromWin32(0x00000000));
+            RegisterLayerInfo(Layer.DrillDrawing, 15, ColorTranslator.FromWin32(0x002A00FF));
+            RegisterLayerInfo(Layer.MultiLayer, 1, ColorTranslator.FromWin32(0x00C0C0C0));
+            RegisterLayerInfo(Layer.ConnectLayer, 4, ColorTranslator.FromWin32(0x0075A19E));
+            RegisterLayerInfo(Layer.BackGroundLayer, 5, ColorTranslator.FromWin32(0x00000000));
+            RegisterLayerInfo(Layer.DRCErrorLayer, 0, ColorTranslator.FromWin32(0x0000FF00));
+            RegisterLayerInfo(Layer.HighlightLayer, 0, ColorTranslator.FromWin32(0x00FFFFFF));
+            RegisterLayerInfo(Layer.GridColor1, 101, ColorTranslator.FromWin32(0x005C4D4D));
+            RegisterLayerInfo(Layer.GridColor10, 100, ColorTranslator.FromWin32(0x00908D91));
+            RegisterLayerInfo(Layer.PadHoleLayer, 1, ColorTranslator.FromWin32(0x00909100));
+            RegisterLayerInfo(Layer.ViaHoleLayer, 1, ColorTranslator.FromWin32(0x00006281));
+        }
+
+        public static IEnumerable<string> Names =>
+            _info.Values.OrderBy(m => m.Id).Select(m => m.InternalName);
+
+        public static IEnumerable<Layer> Values =>
+            _info.Keys.OrderBy(l => l.ToByte());
+
+        public static LayerMetadata Get(Layer layer) =>
+            _info.TryGetValue(layer, out var result) ? result : null;
+
+        public static LayerMetadata Get(string layerName) =>
+            _info.Values.FirstOrDefault(li => layerName.Equals(li.InternalName, StringComparison.InvariantCultureIgnoreCase));
+
+        /// <summary>
+        /// Layer identifier as a byte.
+        /// </summary>
+        public byte Id { get; }
+
+        /// <summary>
+        /// Layer internal name.
+        /// </summary>
+        public string InternalName => InternalNames[Id];
+
+        /// <summary>
+        /// Layer long name.
+        /// </summary>
+        public string LongName => LongNames[Id];
+
+        /// <summary>
+        /// Layer medium name.
+        /// </summary>
+        public string MediumName => MediumNames[Id];
+
+        /// <summary>
+        /// Layer short name.
+        /// </summary>
+        public string ShortName => ShortNames[Id];
+
+        /// <summary>
+        /// Layer draw priority. the lower, the higher priority.
+        /// </summary>
+        public int DrawPriority { get; }
+
+        /// <summary>
+        /// Color for the layer.
+        /// </summary>
+        public Color Color { get; }
+
+        internal string Name => InternalName;
+        internal static string GetName(Layer layer) => layer.Name;
+        internal static Color GetColor(Layer layer) => layer.Color;
+        internal static Color GetColor(string layerName) => Layer.GetLayerColor(layerName);
+
+        private LayerMetadata(byte id, int drawPriority, Color color)
+        {
+            Id = id;
+            DrawPriority = drawPriority;
+            Color = color;
+        }
+    }
+}

--- a/AltiumSharp/BasicTypes/Parameters.cs
+++ b/AltiumSharp/BasicTypes/Parameters.cs
@@ -347,7 +347,7 @@ namespace AltiumSharp.BasicTypes
                 }
                 else
                 {
-                    AddData(key, value);
+                    InternalAddData(key, value);
                 }
             }
         }
@@ -403,7 +403,7 @@ namespace AltiumSharp.BasicTypes
         /// </summary>
         /// <param name="key">Key of the value to be added.</param>
         /// <param name="data">String representation of the value to be added.</param>
-        private void AddData(string key, string data, bool forceAddKey = false)
+        private void InternalAddData(string key, string data, bool forceAddKey = false)
         {
             var parameterValue = new Parameter(key, data, Level);
             
@@ -435,11 +435,11 @@ namespace AltiumSharp.BasicTypes
             {
                 if (value is IConvertible convertible)
                 {
-                    AddData(key, convertible.ToString(CultureInfo.InvariantCulture));
+                    InternalAddData(key, convertible.ToString(CultureInfo.InvariantCulture));
                 }
                 else
                 {
-                    AddData(key, value.ToString());
+                    InternalAddData(key, value.ToString());
                 }
             }
             else
@@ -474,7 +474,7 @@ namespace AltiumSharp.BasicTypes
             if (!ignoreDefaultValue || value != 0)
             {
                 var format = "#########0." + string.Concat(Enumerable.Repeat("0", decimals)) + string.Concat(Enumerable.Repeat("#", 6 - decimals));
-                AddData(key, value.ToString(format, CultureInfo.InvariantCulture));
+                InternalAddData(key, value.ToString(format, CultureInfo.InvariantCulture));
             }
             else
             {
@@ -489,7 +489,7 @@ namespace AltiumSharp.BasicTypes
         {
             if (!ignoreDefaultValue || value)
             {
-                AddData(key, value ? ParameterValue.TrueValues[UseLongBooleans ? 1 : 0] : ParameterValue.FalseValues[UseLongBooleans ? 1 : 0]);
+                InternalAddData(key, value ? ParameterValue.TrueValues[UseLongBooleans ? 1 : 0] : ParameterValue.FalseValues[UseLongBooleans ? 1 : 0]);
             }
             else
             {
@@ -504,7 +504,7 @@ namespace AltiumSharp.BasicTypes
         {
             if (!ignoreDefaultValue || (int)value != 0)
             {
-                AddData(key, value.ToMils().ToString("#####0.#####mil", CultureInfo.InvariantCulture));
+                InternalAddData(key, value.ToMils().ToString("#####0.#####mil", CultureInfo.InvariantCulture));
             }
             else
             {

--- a/AltiumSharp/BasicTypes/Parameters.cs
+++ b/AltiumSharp/BasicTypes/Parameters.cs
@@ -134,6 +134,8 @@ namespace AltiumSharp.BasicTypes
         /// </param>
         public IEnumerable<ParameterValue> AsEnumerable(char? separator = null)
         {
+            if (string.IsNullOrEmpty(_data)) yield break;
+
             foreach (var item in _data.Split(separator ?? ListSeparator))
             {
                 yield return new ParameterValue(item, '\0');

--- a/AltiumSharp/BasicTypes/Unit.cs
+++ b/AltiumSharp/BasicTypes/Unit.cs
@@ -141,7 +141,7 @@ namespace AltiumSharp.BasicTypes
         /// <param name="unit">Unit of the resulting coordinate.</param>
         /// <returns>Returns the output coordinate.</returns>
         public static Coord StringToCoordUnit(string input, out Unit unit) =>
-            TryStringToCoordUnit(input, out var result, out unit) ? result : throw new FormatException();
+            TryStringToCoordUnit(input, out var result, out unit) ? result : throw new FormatException($"Invalid coordinate: {input}");
 
         /// <summary>
         /// Converts a coordinate and unit to its string representation.

--- a/AltiumSharp/BasicTypes/Utils.cs
+++ b/AltiumSharp/BasicTypes/Utils.cs
@@ -77,10 +77,10 @@ namespace AltiumSharp.BasicTypes
             double.Parse(str, NumberStyles.Any, CultureInfo.InvariantCulture);
 
         /// <summary>
-        /// Makes sure angle is between [0, 360)
+        /// Makes sure angle is between [0, 360]
         /// </summary>
         public static double NormalizeAngle(double degrees) =>
-            (degrees % 360.0 + 360.0) % 360.0;
+            (degrees > 0 && degrees % 360.0 == 0) ? 360.0 : (degrees % 360.0 + 360.0) % 360.0;
 
         internal static bool TryStringToDouble(string str, out double value) =>
             double.TryParse(str, NumberStyles.Any, CultureInfo.InvariantCulture, out value);

--- a/AltiumSharp/BasicTypes/Utils.cs
+++ b/AltiumSharp/BasicTypes/Utils.cs
@@ -88,6 +88,19 @@ namespace AltiumSharp.BasicTypes
         internal static string Format(string format, params object[] args) =>
             string.Format(CultureInfo.InvariantCulture, format, args);
 
+        internal static ref CoordPoint[] TranslatePoints(ref CoordPoint[] points, in CoordPoint value)
+        {
+            if (value == CoordPoint.Zero) return ref points;
+
+            for (var i = 0; i < points.Length; ++i)
+            {
+                var p = points[i];
+                points[i] = new CoordPoint(p.X + value.X, p.Y + value.Y);
+            }
+
+            return ref points;
+        }
+
         internal static ref CoordPoint[] RotatePoints(ref CoordPoint[] points,
             in CoordPoint anchor, double angleDegrees)
         {

--- a/AltiumSharp/CompoundFileWriter.cs
+++ b/AltiumSharp/CompoundFileWriter.cs
@@ -80,10 +80,15 @@ namespace AltiumSharp
         /// </summary>
         /// <param name="writer">Binary data writer.</param>
         /// <param name="data">Block data.</param>
-        internal static void WriteBlock(BinaryWriter writer, byte[] data, byte flags = 0)
+        /// <param name="flags">Block flags.</param>
+        /// <param name="emptySize">Size considered as an empty block that will not have content data written.</param>
+        internal static void WriteBlock(BinaryWriter writer, byte[] data, byte flags = 0, int emptySize = 0)
         {
             writer.Write((flags << 24) | data.Length); // flags + size
-            writer.Write(data ?? Array.Empty<byte>()); // data
+            if (data.Length > emptySize)
+            {
+                writer.Write(data ?? Array.Empty<byte>()); // data
+            }
         }
 
         /// <summary>
@@ -91,7 +96,9 @@ namespace AltiumSharp
         /// </summary>
         /// <param name="writer">Binary data writer.</param>
         /// <param name="serializer">Serializer that will generate the block data.</param>
-        internal static void WriteBlock(BinaryWriter writer, Action<BinaryWriter> serializer, byte flags = 0)
+        /// <param name="flags">Block flags.</param>
+        /// <param name="emptySize">Size considered as an empty block that will not have content data written.</param>
+        internal static void WriteBlock(BinaryWriter writer, Action<BinaryWriter> serializer, byte flags = 0, int emptySize = 0)
         {
             var posStart = writer.BaseStream.Position;
 
@@ -104,7 +111,10 @@ namespace AltiumSharp
             int length = (int)(posEnd - posStart - sizeof(int));
             writer.Write(((flags << 24) | length)); // write length header
 
-            writer.BaseStream.Position = posEnd;
+            if (length > emptySize)
+            {
+                writer.BaseStream.Position = posEnd;
+            }
         }
 
         /// <summary>

--- a/AltiumSharp/Records/Pcb/PcbPad.cs
+++ b/AltiumSharp/Records/Pcb/PcbPad.cs
@@ -53,68 +53,77 @@ namespace AltiumSharp.Records
                 }
             }
         }
-        
+
+        public CoordPoint Size
+        {
+            get => SizeTop;
+            set => SetSizeAll(value);
+        }
+
+        public PcbPadShape Shape
+        {
+            get => ShapeTop;
+            set => SetShapeAll(value);
+        }
+
+        public byte CornerRadius
+        {
+            get => CornerRadiusTop;
+            set => SetCornerRadiusAll(value);
+        }
+
         public CoordPoint SizeTop
         {
             get => SizeLayers[0];
-            set => SizeLayers[0] = value;
+            set => SetSizeTop(value);
         }
         
         public PcbPadShape ShapeTop
         {
             get => ShapeLayers[0];
-            set => ShapeLayers[0] = value;
+            set => SetShapeTop(value);
         }
         
         public byte CornerRadiusTop
         {
             get => ShapeTop == PcbPadShape.RoundedRectangle ? CornerRadiusPercentage[0] : (byte)0;
-            set => CornerRadiusPercentage[0] = value;
+            set => SetCornerRadiusTop(value);
         }
         
         public CoordPoint SizeMiddle
         {
             get => SizeLayers[1];
-            set
-            {
-                for (int i = 1; i < 31; ++i) SizeLayers[i] = value;
-            }
+            set => SetSizeMiddle(value);
         }
         
         public PcbPadShape ShapeMiddle
         {
             get => ShapeLayers[1];
-            set
-            {
-                for (int i = 1; i < 31; ++i) ShapeLayers[i] = value;
-            }
+            set => SetShapeMiddle(value);
         }
         
         public byte CornerRadiusMid
         {
             get => ShapeMiddle == PcbPadShape.RoundedRectangle ? CornerRadiusPercentage[1] : (byte)0;
-            set
-            {
-                for (int i = 1; i < 31; ++i) CornerRadiusPercentage[i] = value;
-            }
+            set => SetCornerRadiusMiddle(value);
         }
         
         public CoordPoint SizeBottom
         {
             get => SizeLayers[31];
-            set => SizeLayers[31] = value;
+            set => SetSizeBottom(value);
         }
         
         public PcbPadShape ShapeBottom
         {
             get => ShapeLayers[31];
-            set => ShapeLayers[31] = value;
+            set => SetShapeBottom(value);
         }
         
         public byte CornerRadiusBot
         {
             get => ShapeBottom == PcbPadShape.RoundedRectangle ? CornerRadiusPercentage[31] : (byte)0;
-            set => CornerRadiusPercentage[31] = value;
+            set => SetCornerRadiusBottom(value);
         }
         
         public CoordPoint OffsetFromHoleCenter
@@ -231,5 +240,140 @@ namespace AltiumSharp.Records
             }
             return result;
         }
+
+        private void SetSizeAll(CoordPoint value)
+        {
+            for (int i = 0; i < SizeLayers.Count; ++i)
+            {
+                SizeLayers[i] = value;
+            }
+        }
+
+        private void SetSizeTop(CoordPoint value)
+        {
+            if (StackMode == PcbStackMode.Simple)
+            {
+                SetSizeAll(value);
+            }
+            else
+            {
+                SizeLayers[0] = value;
+            }
+        }
+
+        private void SetSizeMiddle(CoordPoint value)
+        {
+            for (int i = 1; i < SizeLayers.Count - 1; ++i)
+            {
+                SizeLayers[i] = value;
+            }
+        }
+
+        private void SetSizeBottom(CoordPoint value)
+        {
+            if (StackMode == PcbStackMode.Simple)
+            {
+                SetSizeAll(value);
+            }
+            else
+            {
+                SizeLayers[SizeLayers.Count - 1] = value;
+            }
+        }
+
+        private void SetShapeAll(PcbPadShape value)
+        {
+            for (int i = 0; i < ShapeLayers.Count; ++i)
+            {
+                ShapeLayers[i] = value;
+            }
+        }
+
+        private void SetShapeTop(PcbPadShape value)
+        {
+            if (StackMode == PcbStackMode.Simple)
+            {
+                SetShapeAll(value);
+            }
+            else
+            {
+                ShapeLayers[0] = value;
+            }
+        }
+
+        private void SetShapeMiddle(PcbPadShape value)
+        {
+            if (StackMode == PcbStackMode.Simple)
+            {
+                SetShapeAll(value);
+            }
+            else
+            {
+                for (int i = 1; i < ShapeLayers.Count - 1; ++i)
+                {
+                    ShapeLayers[i] = value;
+                }
+            }
+        }
+
+        private void SetShapeBottom(PcbPadShape value)
+        {
+            if (StackMode == PcbStackMode.Simple)
+            {
+                SetShapeAll(value);
+            }
+            else
+            {
+                ShapeLayers[ShapeLayers.Count - 1] = value;
+            }
+        }
+
+        private void SetCornerRadiusAll(byte value)
+        {
+            for (int i = 0; i < CornerRadiusPercentage.Count; ++i)
+            {
+                CornerRadiusPercentage[i] = value;
+            }
+        }
+
+        private void SetCornerRadiusTop(byte value)
+        {
+            if (StackMode == PcbStackMode.Simple)
+            {
+                SetCornerRadiusAll(value);
+            }
+            else
+            {
+                CornerRadiusPercentage[0] = value;
+            }
+        }
+
+        private void SetCornerRadiusMiddle(byte value)
+        {
+            if (StackMode == PcbStackMode.Simple)
+            {
+                SetCornerRadiusAll(value);
+            }
+            else
+            {
+                for (int i = 1; i < CornerRadiusPercentage.Count - 1; ++i)
+                {
+                    CornerRadiusPercentage[i] = value;
+                }
+            }
+        }
+
+        private void SetCornerRadiusBottom(byte value)
+        {
+            if (StackMode == PcbStackMode.Simple)
+            {
+                SetCornerRadiusAll(value);
+            }
+            else
+            {
+                CornerRadiusPercentage[CornerRadiusPercentage.Count - 1] = value;
+            }
+        }
+
     }
 }

--- a/AltiumSharp/Records/Sch/SchComponent.cs
+++ b/AltiumSharp/Records/Sch/SchComponent.cs
@@ -28,6 +28,7 @@ namespace AltiumSharp.Records
         public int ComponentKind { get; set; }
         public string AliasList { get; set; }
         public int AllPinCount => Primitives.OfType<SchPin>().Count();
+        public TextOrientations Orientation { get; set; }
 
         /// <summary>
         /// DesignItemId is kept for compatibility as it should be the exact same as LibReference,
@@ -104,6 +105,7 @@ namespace AltiumSharp.Records
             PartIdLocked = p["PARTIDLOCKED"].AsBool();
             ComponentKind = p["COMPONENTKIND"].AsIntOrDefault();
             AliasList = p["ALIASLIST"].AsStringOrDefault();
+            Orientation = p["ORIENTATION"].AsEnumOrDefault<TextOrientations>();
         }
 
         public override void ExportToParameters(ParameterCollection p)
@@ -117,6 +119,7 @@ namespace AltiumSharp.Records
             p.Add("PARTCOUNT", PartCount + 1);
             p.Add("DISPLAYMODECOUNT", DisplayModeCount);
             p.MoveKeys("INDEXINSHEET");
+            p.Add("ORIENTATION", Orientation);
             p.Add("CURRENTPARTID", CurrentPartId);
             p.Add("SHOWHIDDENPINS", ShowHiddenPins);
             p.Add("LIBRARYPATH", LibraryPath);
@@ -162,14 +165,22 @@ namespace AltiumSharp.Records
                 return false;
             }
 
-            if (primitive.OwnerPartDisplayMode < 0 || primitive.OwnerPartDisplayMode >= DisplayModeCount)
+            if (primitive.OwnerPartDisplayMode == null)
             {
                 primitive.OwnerPartDisplayMode = DisplayMode;
             }
+            else if (primitive.OwnerPartDisplayMode >= DisplayModeCount)
+            {
+                DisplayModeCount = primitive.OwnerPartDisplayMode.Value + 1;
+            }
 
-            if (primitive.OwnerPartId < 0 || primitive.OwnerPartId > PartCount)
+            if (primitive.OwnerPartId == null)
             {
                 primitive.OwnerPartId = CurrentPartId;
+            }
+            else if (primitive.OwnerPartId > PartCount)
+            {
+                PartCount = primitive.OwnerPartId.Value;
             }
 
             return true;

--- a/AltiumSharp/Records/Sch/SchComponent.cs
+++ b/AltiumSharp/Records/Sch/SchComponent.cs
@@ -167,7 +167,7 @@ namespace AltiumSharp.Records
                 primitive.OwnerPartDisplayMode = DisplayMode;
             }
 
-            if (primitive.OwnerPartId < 1 || primitive.OwnerPartId > PartCount)
+            if (primitive.OwnerPartId < 0 || primitive.OwnerPartId > PartCount)
             {
                 primitive.OwnerPartId = CurrentPartId;
             }

--- a/AltiumSharp/Records/Sch/SchDocumentHeader.cs
+++ b/AltiumSharp/Records/Sch/SchDocumentHeader.cs
@@ -19,6 +19,7 @@ namespace AltiumSharp.Records
         public int SheetStyle { get; set; }
         public int SystemFont { get; set; }
         public bool BorderOn { get; set; }
+        public bool TitleBlockOn { get; set; }
         public int SheetNumberSpaceSize { get; internal set; }
         public Color AreaColor { get; set; }
         public bool SnapGridOn { get; set; }
@@ -27,6 +28,9 @@ namespace AltiumSharp.Records
         public Coord VisibleGridSize { get; set; }
         public int CustomX { get; internal set; }
         public int CustomY { get; internal set; }
+        public int CustomXZones { get; internal set; }
+        public int CustomYZones { get; internal set; }
+        public int CustomMarginWidth { get; internal set; }
         public bool UseCustomSheet { get; internal set; }
         public bool ReferenceZonesOn { get; internal set; }
         public bool ShowTemplateGraphics { get; internal set; }
@@ -73,6 +77,7 @@ namespace AltiumSharp.Records
             SheetStyle = p["SHEETSTYLE"].AsIntOrDefault();
             SystemFont = p["SYSTEMFONT"].AsIntOrDefault(1);
             BorderOn = p["BORDERON"].AsBool();
+            TitleBlockOn = p["TITLEBLOCKON"].AsBool();
             SheetNumberSpaceSize = p["SHEETNUMBERSPACESIZE"].AsIntOrDefault();
             AreaColor = p["AREACOLOR"].AsColorOrDefault();
             SnapGridOn = p["SNAPGRIDON"].AsBool();
@@ -81,6 +86,9 @@ namespace AltiumSharp.Records
             VisibleGridSize = Utils.DxpFracToCoord(p["VISIBLEGRIDSIZE"].AsIntOrDefault(), p["VISIBLEGRIDSIZE_FRAC"].AsIntOrDefault());
             CustomX = p["CUSTOMX"].AsIntOrDefault();
             CustomY = p["CUSTOMY"].AsIntOrDefault();
+            CustomXZones = p["CUSTOMXZONES"].AsIntOrDefault();
+            CustomYZones = p["CUSTOMYZONES"].AsIntOrDefault();
+            CustomMarginWidth = p["CUSTOMMARGINWIDTH"].AsIntOrDefault();
             UseCustomSheet = p["USECUSTOMSHEET"].AsBool();
             ReferenceZonesOn = p["REFERENCEZONESON"].AsBool();
             ShowTemplateGraphics = p["SHOWTEMPLATEGRAPHICS"].AsBool();
@@ -111,6 +119,7 @@ namespace AltiumSharp.Records
             p.Add("SHEETSTYLE", SheetStyle);
             p.Add("SYSTEMFONT", SystemFont);
             p.Add("BORDERON", BorderOn);
+            p.Add("TITLEBLOCKON", TitleBlockOn);
             p.Add("SHEETNUMBERSPACESIZE", SheetNumberSpaceSize);
             p.Add("AREACOLOR", AreaColor);
             p.Add("SNAPGRIDON", SnapGridOn);
@@ -127,6 +136,9 @@ namespace AltiumSharp.Records
             }
             p.Add("CUSTOMX", CustomX);
             p.Add("CUSTOMY", CustomY);
+            p.Add("CUSTOMXZONES", CustomXZones);
+            p.Add("CUSTOMYZONES", CustomYZones);
+            p.Add("CUSTOMMARGINWIDTH", CustomMarginWidth);
             p.Add("USECUSTOMSHEET", UseCustomSheet);
             p.Add("REFERENCEZONESON", ReferenceZonesOn);
             p.Add("SHOWTEMPLATEGRAPHICS", ShowTemplateGraphics);

--- a/AltiumSharp/Records/Sch/SchParameter.cs
+++ b/AltiumSharp/Records/Sch/SchParameter.cs
@@ -11,7 +11,7 @@ namespace AltiumSharp.Records
         public bool ShowName { get; set; }
         public string Description { get; set; }
         public int ReadOnlyState { get; set; }
-        public string UniqueId { get; internal set; }
+        public string UniqueId { get; set; }
         public string Value => string.IsNullOrEmpty(Description) ? base.DisplayText : Description;
         internal override string DisplayText => ShowName ? $"{Name}: {Value}" : Value;
         public override bool IsOfCurrentPart => true;
@@ -28,7 +28,6 @@ namespace AltiumSharp.Records
             OwnerPartId = -1;
             Text = "*";
             IsHidden = true;
-            UniqueId = Utils.GenerateUniqueId();
         }
 
         public override string ToString()

--- a/AltiumSharp/Records/Sch/SchPin.cs
+++ b/AltiumSharp/Records/Sch/SchPin.cs
@@ -73,13 +73,13 @@ namespace AltiumSharp.Records
 
         public override bool IsVisible => base.IsVisible && !PinConglomerate.HasFlag(PinConglomerateFlags.Hide);
 
-        public bool NameVisible
+        public bool IsNameVisible
         {
             get => PinConglomerate.HasFlag(PinConglomerateFlags.DisplayNameVisible);
             set => PinConglomerate = PinConglomerate.WithFlag(PinConglomerateFlags.DisplayNameVisible, value);
         }
 
-        public bool DesignatorVisible
+        public bool IsDesignatorVisible
         {
             get => PinConglomerate.HasFlag(PinConglomerateFlags.DesignatorVisible);
             set => PinConglomerate = PinConglomerate.WithFlag(PinConglomerateFlags.DesignatorVisible, value);

--- a/AltiumSharp/Records/Sch/SchPin.cs
+++ b/AltiumSharp/Records/Sch/SchPin.cs
@@ -103,7 +103,6 @@ namespace AltiumSharp.Records
                 PinConglomerateFlags.DesignatorVisible |
                 PinConglomerateFlags.Unknown;
             PinLength = Utils.DxpFracToCoord(30, 0);
-            UniqueId = Utils.GenerateUniqueId();
             Designator = null;
             Name = null;
         }
@@ -184,7 +183,6 @@ namespace AltiumSharp.Records
             p.Add("DESIGNATOR", Designator);
             p.Add("SWAPIDPART", SwapIdPart);
             p.Add("PINPROPAGATIONDELAY", PinPropagationDelay);
-            p.Add("UNIQUEID", UniqueId);
         }
 
         protected override bool DoAdd(SchPrimitive primitive)
@@ -216,7 +214,7 @@ namespace AltiumSharp.Records
 
             if (!string.IsNullOrEmpty(UniqueId))
             {
-                yield return new SchParameter {Name = "PinUniqueId", Text = UniqueId};
+                yield return new SchParameter {Name = "PinUniqueId", Text = UniqueId, Location = Location};
             }
         }
     }

--- a/AltiumSharp/Records/Sch/SchPin.cs
+++ b/AltiumSharp/Records/Sch/SchPin.cs
@@ -63,7 +63,9 @@ namespace AltiumSharp.Records
         public Coord PinLength { get; set; }
         public string Name { get; set; }
         public string Designator { get; set; }
+        public string SwapIdGroup { get; set; }
         public int SwapIdPart { get; set; }
+        public string SwapIdSequence { get; set; }
         public string HiddenNetName { get; set; }
         public string DefaultValue { get; set; }
         public double PinPropagationDelay { get; set; }

--- a/AltiumSharp/Records/Sch/SchPrimitive.cs
+++ b/AltiumSharp/Records/Sch/SchPrimitive.cs
@@ -11,13 +11,13 @@ namespace AltiumSharp.Records
 
         public bool IsNotAccesible { get; set; }
 
-        public int IndexInSheet => (Owner as SchComponent)?.GetPrimitiveIndexOf(this) ?? -1;
+        public int? IndexInSheet => (Owner as SchSheetHeader)?.GetPrimitiveIndexOf(this);
 
         internal int OwnerIndex { get; set; }
 
-        public int OwnerPartId { get; set; }
+        public int? OwnerPartId { get; set; }
 
-        public int OwnerPartDisplayMode { get; set; }
+        public int? OwnerPartDisplayMode { get; set; }
 
         public bool GraphicallyLocked { get; set; }
 
@@ -36,8 +36,6 @@ namespace AltiumSharp.Records
 
         public SchPrimitive() : base()
         {
-            OwnerPartDisplayMode = -1;
-            OwnerPartId = -1;
         }
 
         public IEnumerable<T> GetPrimitivesOfType<T>(bool flatten = true) where T : Primitive
@@ -80,9 +78,9 @@ namespace AltiumSharp.Records
             p.Add("RECORD", Record);
             p.Add("OWNERINDEX", OwnerIndex);
             p.Add("ISNOTACCESIBLE", IsNotAccesible);
-            p.Add("INDEXINSHEET", IndexInSheet);
-            p.Add("OWNERPARTID", OwnerPartId);
-            p.Add("OWNERPARTDISPLAYMODE", OwnerPartDisplayMode);
+            p.Add("INDEXINSHEET", IndexInSheet ?? default);
+            p.Add("OWNERPARTID", OwnerPartId ?? default);
+            p.Add("OWNERPARTDISPLAYMODE", OwnerPartDisplayMode ?? default);
             p.Add("GRAPHICALLYLOCKED", GraphicallyLocked);
         }
 

--- a/AltiumSharp/Records/Sch/SchPrimitive.cs
+++ b/AltiumSharp/Records/Sch/SchPrimitive.cs
@@ -64,7 +64,7 @@ namespace AltiumSharp.Records
             if (p == null) throw new ArgumentNullException(nameof(p));
 
             var recordType = p["RECORD"].AsIntOrDefault();
-            if (recordType != Record) throw new ArgumentException($"Record type mismatch when deserializing. Expected {Record} but got {recordType}", nameof(p));
+            if (Record != 0 && recordType != Record) throw new ArgumentException($"Record type mismatch when deserializing. Expected {Record} but got {recordType}", nameof(p));
 
             OwnerIndex = p["OWNERINDEX"].AsIntOrDefault();
             IsNotAccesible = p["ISNOTACCESIBLE"].AsBool();

--- a/AltiumSharp/Records/Sch/SchPrimitive.cs
+++ b/AltiumSharp/Records/Sch/SchPrimitive.cs
@@ -25,7 +25,7 @@ namespace AltiumSharp.Records
         internal IReadOnlyList<SchPrimitive> Primitives => _primitives;
 
         public virtual bool IsOfCurrentPart =>
-            OwnerPartId == -1 || (Owner is SchComponent component && component.CurrentPartId == OwnerPartId);
+            OwnerPartId <= 0 || (Owner is SchComponent component && component.CurrentPartId == OwnerPartId);
 
         public virtual bool IsOfCurrentDisplayMode =>
             !(Owner is SchComponent) ||

--- a/AltiumSharp/SchWriter.cs
+++ b/AltiumSharp/SchWriter.cs
@@ -153,8 +153,15 @@ namespace AltiumSharp
                 w.Write(ColorTranslator.ToWin32(pin.Color));
                 WritePascalShortString(w, pin.Name);
                 WritePascalShortString(w, pin.Designator);
-                w.Write((byte)0); // TODO: unknown
-                w.Write((byte)0); // TODO: unknown
+                WritePascalShortString(w, pin.SwapIdGroup);
+                var partAndSequence = string.Empty;
+                if (!(pin.SwapIdPart == 0 && string.IsNullOrEmpty(pin.SwapIdSequence)))
+                {
+                    partAndSequence = pin.SwapIdPart != 0
+                        ? $"{pin.SwapIdPart}|&|{pin.SwapIdSequence}"
+                        : $"|&|{pin.SwapIdSequence}";
+                }
+                WritePascalShortString(w, partAndSequence);
                 WritePascalShortString(w, pin.DefaultValue);
             }, (byte)0x01); // flag needs to be 1
 


### PR DESCRIPTION
Pins now have their electrical type arrows drawn.

Support for obtaining short, medium and long layer names.

Implemented missing SchPin functionality like swap pairs.

Implemented some SchDocumentHeader missing properties.

Fixed bug in pin UniqueId persistence.

Fixed PcbLib circle drawing using arcs

Other minor improvements