### PR TITLE
removed NeedsFullStackData check

### DIFF
--- a/AltiumSharp/PcbLibWriter.cs
+++ b/AltiumSharp/PcbLibWriter.cs
@@ -264,43 +264,35 @@ namespace AltiumSharp
                 w.Write((short)0);
             });
 
-            // Write size and shape and parts of hole information
-            if (pad.NeedsFullStackData)
+            WriteBlock(writer, w =>
             {
-                WriteBlock(writer, w =>
+                // 29 items
+                foreach (var padSize in pad.SizeMiddleLayers) w.Write(padSize.X.ToInt32());
+                foreach (var padSize in pad.SizeMiddleLayers) w.Write(padSize.Y.ToInt32());
+                foreach (var padShape in pad.ShapeMiddleLayers) w.Write((byte)padShape);
+
+                w.Write((byte)0); // TODO: Unknown
+                w.Write((byte)pad.HoleShape);
+                w.Write(pad.HoleSlotLength);
+                w.Write((double)pad.HoleRotation);
+
+                // 32 items
+                foreach (var offset in pad.OffsetsFromHoleCenter) w.Write(offset.X.ToInt32());
+                foreach (var offset in pad.OffsetsFromHoleCenter) w.Write(offset.Y.ToInt32());
+
+                w.Write(pad.HasRoundedRectangles);
+                if (pad.HasRoundedRectangles)
                 {
-                    // 29 items
-                    foreach (var padSize in pad.SizeMiddleLayers) w.Write(padSize.X.ToInt32());
-                    foreach (var padSize in pad.SizeMiddleLayers) w.Write(padSize.Y.ToInt32());
-                    foreach (var padShape in pad.ShapeMiddleLayers) w.Write((byte)padShape);
+                    foreach (var padShape in pad.ShapeLayers) w.Write((byte)padShape);
+                }
+                else
+                {
+                    foreach (var padShape in pad.ShapeLayers) w.Write((byte)PcbPadShape.Round); // write dummy value
+                }
 
-                    w.Write((byte)0); // TODO: Unknown
-                    w.Write((byte)pad.HoleShape);
-                    w.Write(pad.HoleSlotLength);
-                    w.Write((double)pad.HoleRotation);
-
-                    // 32 items
-                    foreach (var offset in pad.OffsetsFromHoleCenter) w.Write(offset.X.ToInt32());
-                    foreach (var offset in pad.OffsetsFromHoleCenter) w.Write(offset.Y.ToInt32());
-
-                    w.Write(pad.HasRoundedRectangles);
-                    if (pad.HasRoundedRectangles)
-                    {
-                        foreach (var padShape in pad.ShapeLayers) w.Write((byte)padShape);
-                    }
-                    else
-                    {
-                        foreach (var padShape in pad.ShapeLayers) w.Write((byte)PcbPadShape.Round); // write dummy value
-                    }
-
-                    // 32 items
-                    foreach (var crp in pad.CornerRadiusPercentage) w.Write((byte)crp);
-                });
-            }
-            else
-            {
-                WriteBlock(writer, Array.Empty<byte>());
-            }
+                // 32 items
+                foreach (var crp in pad.CornerRadiusPercentage) w.Write((byte)crp);
+            });
         }
 
         private void WriteFootprintVia(BinaryWriter writer, PcbVia via)


### PR DESCRIPTION
removed NeedsFullStackData check, since its possible to have block with hole parameters, even under Simple stack mode
I have slot shape hole of my pad and it has simple stackmode, so in this case hole information will be not written into file, which seems to be wrong since altium does that.
it took me a while to understand what is wrong, do you have more of such assumptions in code?