### PR TITLE
Outline member of PcbRegion class should not be read only

### DIFF
--- a/AltiumSharp/Records/Pcb/PcbRegion.cs
+++ b/AltiumSharp/Records/Pcb/PcbRegion.cs
@@ -8,7 +8,7 @@ namespace AltiumSharp.Records
     {
         public override PcbPrimitiveObjectId ObjectId => PcbPrimitiveObjectId.Region;
         public ParameterCollection Parameters { get; internal set; } = new ParameterCollection();
-        public List<CoordPoint> Outline { get; } = new List<CoordPoint>();
+        public List<CoordPoint> Outline { get; set; } = new List<CoordPoint>();
 
         public override CoordRect CalculateBounds()
         {


### PR DESCRIPTION
Outline member of PcbRegion class should not be read only in order to obvoius creating PcbRegion instance, same as PcbMetaTrack for example