### PR TITLE
The header specified by a file created by Altium is always(?) "Protel…

### DIFF
--- a/AltiumSharp/Records/Sch/SchLibHeader.cs
+++ b/AltiumSharp/Records/Sch/SchLibHeader.cs
@@ -32,7 +32,7 @@ namespace OriginalCircuit.AltiumSharp.Records
                 throw new ArgumentNullException(nameof(p));
 
             var header = p["HEADER"].AsStringOrDefault();
-            if (header == null || string.Equals(header, Header, StringComparison.InvariantCultureIgnoreCase))
+            if (header == null || !string.Equals(header, Header, StringComparison.InvariantCultureIgnoreCase))
                 throw new ArgumentOutOfRangeException($"{nameof(p)}[\"HEADER\"]");
 
             MinorVersion = p["MINORVERSION"].AsIntOrDefault();


### PR DESCRIPTION
… for Windows - Schematic Library Editor Binary File Version 5.0".