### PR TITLE
Connectivity: Prevent duplicate logical pin assignments

### DIFF
--- a/src/OriginalCircuit.Altium/Connectivity/Internal/NetlistAssembler.cs
+++ b/src/OriginalCircuit.Altium/Connectivity/Internal/NetlistAssembler.cs
@@ -59,9 +59,14 @@ internal sealed class NetlistAssembler
         foreach (var (root, group) in groups)
         {
             var pins = new List<NetPin>();
+            var pinKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             foreach (var e in group)
                 if (e.Kind == ElementKind.Pin && e.NetPin is not null)
-                    pins.Add(e.NetPin);
+                {
+                    var logicalKey = $"{e.NetPin.SheetInstanceId}\0{e.NetPin.Key}";
+                    if (pinKeys.Add(logicalKey))
+                        pins.Add(e.NetPin);
+                }
 
             var hasLabel = _labelsByRoot.TryGetValue(root, out var labels) && labels.Count > 0;
             var (name, scope, explicitName) = ChooseName(root, group, pins, hasLabel ? labels! : null);

--- a/src/OriginalCircuit.Altium/Connectivity/Internal/SheetGraph.cs
+++ b/src/OriginalCircuit.Altium/Connectivity/Internal/SheetGraph.cs
@@ -87,11 +87,14 @@ internal sealed class SheetGraph
                 if (ip is not SchPin pin)
                     continue;
 
-                // A multi-part component record carries pins from every part, but only the displayed
-                // part (CurrentPartId) is actually placed on this sheet — the other parts' pins keep
-                // stale positions. Include only the current part's pins (plus part-shared pins).
+                // A component record carries pins from every part and every alternative display mode,
+                // but only the selected part/mode is actually placed on this sheet. The other pins
+                // retain coordinates for their inactive representation and can otherwise connect to
+                // adjacent wires (notably on dual-row headers).
                 if (sc.PartCount > 1 && sc.CurrentPartId > 0
                     && pin.OwnerPartId > 0 && pin.OwnerPartId != sc.CurrentPartId)
+                    continue;
+                if (pin.OwnerPartDisplayMode != sc.DisplayMode)
                     continue;
 
                 var tip = SchDesignators.PinTip(pin);
@@ -261,6 +264,11 @@ internal sealed class SheetGraph
         // Rule 1 & 3a: coincident connection points connect (shared endpoints, pin-tip on wire vertex).
         Points.UnionCoincident(uf);
 
+        // A symbol may expose the same physical package pad at multiple graphical locations. Altium
+        // identifies that pad by component plus pin designator, so all of those endpoints are one
+        // electrical node even when the drawing locations differ.
+        UnifyDuplicatePhysicalPins(uf);
+
         // Rule 2 & 3b: a connection point on the INTERIOR of a conductor connects (T-junction).
         // Applies to any element's points landing on a different conductor's interior.
         foreach (var e in Elements)
@@ -290,6 +298,31 @@ internal sealed class SheetGraph
 
         // Rule 3d: collinear overlapping conductor segments connect.
         ApplyCollinearOverlap(uf);
+    }
+
+    private void UnifyDuplicatePhysicalPins(UnionFind uf)
+    {
+        var pinsByComponent = new Dictionary<SchComponent, Dictionary<string, int>>(
+            ReferenceEqualityComparer.Instance);
+
+        foreach (var element in Elements)
+        {
+            if (element.Kind != ElementKind.Pin
+                || element.NetPin is null
+                || string.IsNullOrEmpty(element.PinDesignator))
+                continue;
+
+            if (!pinsByComponent.TryGetValue(element.NetPin.Component, out var pinsByDesignator))
+            {
+                pinsByDesignator = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+                pinsByComponent.Add(element.NetPin.Component, pinsByDesignator);
+            }
+
+            if (pinsByDesignator.TryGetValue(element.PinDesignator, out var firstElementId))
+                uf.Union(firstElementId, element.Id);
+            else
+                pinsByDesignator.Add(element.PinDesignator, element.Id);
+        }
     }
 
     private void ApplyCollinearOverlap(UnionFind uf)

--- a/tests/OriginalCircuit.Altium.Tests/Connectivity/SchematicNetlistTests.cs
+++ b/tests/OriginalCircuit.Altium.Tests/Connectivity/SchematicNetlistTests.cs
@@ -144,6 +144,87 @@ public class SchematicNetlistTests
         Assert.True(net.IsNamedExplicitly);
     }
 
+    [Theory]
+    [InlineData(0, "MODE0")]
+    [InlineData(1, "MODE1")]
+    public void Only_Selected_Display_Mode_Pins_Participate_In_Connectivity(
+        int displayMode, string expectedNet)
+    {
+        var component = new SchComponent
+        {
+            Name = "U1",
+            PartCount = 1,
+            CurrentPartId = 1,
+            DisplayModeCount = 2,
+            DisplayMode = displayMode,
+        };
+        component.AddParameter(new SchParameter { Name = "Designator", Value = "U1" });
+
+        var mode0Pin = SchPin.Create("1")
+            .At(Coord.FromMils(0), Coord.FromMils(0))
+            .Length(Coord.Zero)
+            .Orient(PinOrientation.Right)
+            .Build();
+        mode0Pin.OwnerPartDisplayMode = 0;
+        component.AddPin(mode0Pin);
+
+        var mode1Pin = SchPin.Create("1")
+            .At(Coord.FromMils(0), Coord.FromMils(200))
+            .Length(Coord.Zero)
+            .Orient(PinOrientation.Right)
+            .Build();
+        mode1Pin.OwnerPartDisplayMode = 1;
+        component.AddPin(mode1Pin);
+
+        var netlist = Solve(
+            component,
+            Wire((0, 0), (100, 0)),
+            Wire((0, 200), (100, 200)),
+            Label("MODE0", 50, 0),
+            Label("MODE1", 50, 200));
+
+        Assert.Equal(expectedNet, netlist.NetForPin("U1", "1")?.Name);
+        Assert.Single(
+            netlist.Nets.SelectMany(net => net.Pins),
+            pin => pin.Key == "U1.1");
+    }
+
+    [Fact]
+    public void Duplicate_Pin_Designators_On_Component_Unify_By_Physical_Pad()
+    {
+        var component = new SchComponent
+        {
+            Name = "U1",
+            PartCount = 1,
+            CurrentPartId = 1,
+        };
+        component.AddParameter(new SchParameter { Name = "Designator", Value = "U1" });
+
+        component.AddPin(SchPin.Create("6")
+            .At(Coord.FromMils(100), Coord.FromMils(0))
+            .Length(Coord.Zero)
+            .Orient(PinOrientation.Right)
+            .Build());
+        component.AddPin(SchPin.Create("6")
+            .At(Coord.FromMils(100), Coord.FromMils(200))
+            .Length(Coord.Zero)
+            .Orient(PinOrientation.Right)
+            .Build());
+
+        var netlist = Solve(
+            component,
+            Wire((0, 0), (100, 0)),
+            Wire((0, 200), (100, 200)),
+            Power("GND", 0, 0));
+
+        var padNets = netlist.Nets
+            .Where(net => net.Pins.Any(pin => pin.Key == "U1.6"))
+            .ToList();
+        var padNet = Assert.Single(padNets);
+        Assert.Equal("GND", padNet.Name);
+        Assert.Single(padNet.Pins, pin => pin.Key == "U1.6");
+    }
+
     [Fact]
     public void Power_Objects_Unify_Globally_By_Name()
     {


### PR DESCRIPTION
## Summary

Two connectivity defects let a component's inactive or duplicated graphics distort the extracted netlist. Pins belonging to a display mode other than the component's selected one still participated in connectivity, so an alternate symbol graphic (notably dual-row header alternates) could capture adjacent nets. And a symbol exposing the same physical package pad at multiple graphical locations produced multiple independent logical pins, so one pad's endpoints could land in different nets or a net could list the same pin more than once.

## Changes

- `SheetGraph` now skips pins whose `OwnerPartDisplayMode` differs from the component's selected `DisplayMode`, extending the existing inactive-part (`CurrentPartId`) filter to inactive display modes.
- New `SheetGraph.UnifyDuplicatePhysicalPins` unions all graphical endpoints that share a physical package pad (component + pin designator), so they form one electrical node even when drawn at different locations.
- `NetlistAssembler` emits one logical pin per sheet instance and pad, deduplicating by `SheetInstanceId` plus pin key when assembling each net's pin list.
- New tests in `SchematicNetlistTests` covering both behaviors.

## Test Plan

- [x] Existing tests pass (`dotnet test`) — full suite at this commit: 853 passed, 0 failed, 10 skipped (pre-existing data-dependent skips, unrelated to this change)
- [x] New tests added for new behavior — `Only_Selected_Display_Mode_Pins_Participate_In_Connectivity` (Theory, run for both display modes: each mode's pin connects only to its own net and the netlist contains the logical pin exactly once) and `Duplicate_Pin_Designators_On_Component_Unify_By_Physical_Pad` (both graphical locations of pad 6 resolve to a single net listing the pin once)

## Checklist

- [x] Code follows existing style and conventions
- [x] Public API changes are documented with XML doc comments — there are no public API changes: `NetlistAssembler` and `SheetGraph` are `internal`, the new `UnifyDuplicatePhysicalPins` is `private`, and the properties the tests use (`SchPin.OwnerPartDisplayMode`, `SchComponent.DisplayMode`) already existed
- [x] No breaking changes (or clearly identified below) — no API signature changes. Netlist extraction output does change for affected schematics, which is the fix itself: pins of unselected display modes no longer join nets, and endpoints sharing a physical pad now merge into one logical pin instead of appearing as duplicates.
