### PR TITLE
Connectivity: instantiate each document once under flat/global net scope

### DIFF
--- a/src/OriginalCircuit.Altium/Connectivity/Internal/HierarchyWalker.cs
+++ b/src/OriginalCircuit.Altium/Connectivity/Internal/HierarchyWalker.cs
@@ -68,8 +68,21 @@ internal sealed class HierarchyWalker
     public List<SheetInstanceInternal> Instances { get; } = new();
     public List<Boundary> Boundaries { get; } = new();
 
-    public void Walk(AltiumProject project)
+    private bool _dedupeDuplicateSheetRefs;
+    private readonly HashSet<string> _instantiated = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <param name="project">The project whose hierarchy to walk.</param>
+    /// <param name="dedupeDuplicateSheetRefs">
+    /// When set, a document referenced by several plain sheet symbols is instantiated only
+    /// once and the remaining references are treated as navigation aids. This matches the
+    /// flat/global net-identifier scopes, where block-diagram overview pages routinely
+    /// reference the working sheets a second time and Altium does not clone channels
+    /// (components exist once per document; identifiers merge by name). Repeat() channels
+    /// are unaffected.
+    /// </param>
+    public void Walk(AltiumProject project, bool dedupeDuplicateSheetRefs = false)
     {
+        _dedupeDuplicateSheetRefs = dedupeDuplicateSheetRefs;
         foreach (var (rootName, rootDoc) in DetermineRoots(project))
         {
             var ancestors = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { rootName };
@@ -118,8 +131,18 @@ internal sealed class HierarchyWalker
                 continue;
             }
 
+            if (_dedupeDuplicateSheetRefs && !sym.Repeat.IsRepeated && !_instantiated.Add(childName))
+            {
+                _diagnostics.Add(new AltiumDiagnostic(DiagnosticSeverity.Info,
+                    $"Sheet '{childName}' is referenced again under '{path}'; flat scope keeps a single instance."));
+                continue;
+            }
+
             var repeat = sym.Repeat;
-            var repeatedChild = childInstanceCounts.GetValueOrDefault(childName) > 1;
+            // Under flat-scope dedupe a plain symbol's document is instantiated exactly once,
+            // so it must not count as a repeated (channel-private) sheet.
+            var repeatedChild = childInstanceCounts.GetValueOrDefault(childName) > 1 &&
+                                !(_dedupeDuplicateSheetRefs && !repeat.IsRepeated);
             var symbolName = string.IsNullOrEmpty(sym.SheetName) ? StripExt(childName) : sym.SheetName;
             var symUid = sym.UniqueId ?? symbolName;
 

--- a/src/OriginalCircuit.Altium/Connectivity/ProjectNetlistBuilder.cs
+++ b/src/OriginalCircuit.Altium/Connectivity/ProjectNetlistBuilder.cs
@@ -56,8 +56,12 @@ public static class ProjectNetlistBuilder
         var scope = NetIdentifierScopeReader.Resolve(rawScope, hasSheetSymbols);
 
         // --- Walk the hierarchy into sheet instances ---
+        // In flat/global scope, duplicate plain sheet references (block-diagram overview
+        // pages) do not clone channels: identifiers merge by name and components exist once
+        // per document, so each document is instantiated once.
         var walker = new HierarchyWalker(docsByName, diagnostics);
-        walker.Walk(project);
+        walker.Walk(project,
+            dedupeDuplicateSheetRefs: scope is NetIdentifierScope.Flat or NetIdentifierScope.Global);
 
         var instances = walker.Instances;
         if (instances.Count == 0)


### PR DESCRIPTION
## Summary

Block-diagram overview pages routinely reference the working sheets a second time for
navigation (a micromodules project references one sheet 17 times from its top-level
overview). The hierarchy walker treated every reference as a multi-channel instance, so
the project netlist invented per-reference channels with channel-private power nets —
GND fell apart into per-sheet islands.

Under the flat and global net-identifier scopes Altium does not clone channels:
identifiers merge by name and components exist once per document. The walker now
instantiates each document once under those scopes. `Repeat()` channels and
hierarchical-scope projects are unaffected.

## Changes

- `HierarchyWalker.Walk` gains an optional `dedupeDuplicateSheetRefs` parameter
  (default `false`, preserving current behavior). When set, a document referenced by
  several plain sheet symbols is instantiated once; later references are skipped with an
  `Info` diagnostic, and the surviving instance is not flagged as a repeated channel.
- `ProjectNetlistBuilder` enables the flag when the resolved net-identifier scope is
  `Flat` or `Global`; hierarchical-scope projects walk exactly as before.

## Test Plan

- [x] Existing tests pass (`dotnet test`) — 850 passed, 0 failed, 10 skipped (tests requiring local sample files)
- [ ] New tests added for new behavior

## Checklist

- [x] Code follows existing style and conventions
- [x] Public API changes are documented with XML doc comments
- [x] No breaking changes (`dedupeDuplicateSheetRefs` is optional; the default keeps existing behavior)
