### PR TITLE
Fix SchLib vertex coordinate units

### DIFF
--- a/src/OriginalCircuit.Altium/Serialization/Readers/SchLibReader.cs
+++ b/src/OriginalCircuit.Altium/Serialization/Readers/SchLibReader.cs
@@ -2317,11 +2317,10 @@ public sealed class SchLibReader
         if (string.IsNullOrEmpty(value))
             return false;
 
-        // Schematic uses 10 units per mil (different from PCB's 10000)
+        // SchLib vertex records use DXP units: one stored unit is 10 mils.
         if (int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var intValue))
         {
-            // Convert from schematic units to internal units
-            result = Coord.FromRaw(intValue * 1000); // Scale up
+            result = Coord.FromRaw(intValue * 100_000);
             return true;
         }
 

--- a/src/OriginalCircuit.Altium/Serialization/Writers/SchDocWriter.cs
+++ b/src/OriginalCircuit.Altium/Serialization/Writers/SchDocWriter.cs
@@ -87,9 +87,9 @@ public sealed class SchDocWriter
             case SchRectangle rect: SchLibWriter.WriteRectangleRecord(writer, rect, ref index, ownerIndex); break;
             case SchLabel label: SchLibWriter.WriteLabelRecord(writer, label, ref index, ownerIndex); break;
             case SchArc arc: SchLibWriter.WriteArcRecord(writer, arc, ref index, ownerIndex); break;
-            case SchPolygon polygon: SchLibWriter.WritePolygonRecord(writer, polygon, ref index, ownerIndex, SchLibWriter.CoordToDxpUnits); break;
-            case SchPolyline polyline: SchLibWriter.WritePolylineRecord(writer, polyline, ref index, ownerIndex, SchLibWriter.CoordToDxpUnits); break;
-            case SchBezier bezier: SchLibWriter.WriteBezierRecord(writer, bezier, ref index, ownerIndex, SchLibWriter.CoordToDxpUnits); break;
+            case SchPolygon polygon: SchLibWriter.WritePolygonRecord(writer, polygon, ref index, ownerIndex); break;
+            case SchPolyline polyline: SchLibWriter.WritePolylineRecord(writer, polyline, ref index, ownerIndex); break;
+            case SchBezier bezier: SchLibWriter.WriteBezierRecord(writer, bezier, ref index, ownerIndex); break;
             case SchEllipse ellipse: SchLibWriter.WriteEllipseRecord(writer, ellipse, ref index, ownerIndex); break;
             case SchRoundedRectangle roundedRect: SchLibWriter.WriteRoundedRectangleRecord(writer, roundedRect, ref index, ownerIndex); break;
             case SchPie pie: SchLibWriter.WritePieRecord(writer, pie, ref index, ownerIndex); break;
@@ -361,13 +361,13 @@ public sealed class SchDocWriter
             SchLibWriter.WriteArcRecord(writer, (SchArc)arc, ref index, ownerIndex);
 
         foreach (var polygon in component.Polygons)
-            SchLibWriter.WritePolygonRecord(writer, (SchPolygon)polygon, ref index, ownerIndex, SchLibWriter.CoordToDxpUnits);
+            SchLibWriter.WritePolygonRecord(writer, (SchPolygon)polygon, ref index, ownerIndex);
 
         foreach (var polyline in component.Polylines)
-            SchLibWriter.WritePolylineRecord(writer, (SchPolyline)polyline, ref index, ownerIndex, SchLibWriter.CoordToDxpUnits);
+            SchLibWriter.WritePolylineRecord(writer, (SchPolyline)polyline, ref index, ownerIndex);
 
         foreach (var bezier in component.Beziers)
-            SchLibWriter.WriteBezierRecord(writer, (SchBezier)bezier, ref index, ownerIndex, SchLibWriter.CoordToDxpUnits);
+            SchLibWriter.WriteBezierRecord(writer, (SchBezier)bezier, ref index, ownerIndex);
 
         foreach (var ellipse in component.Ellipses)
             SchLibWriter.WriteEllipseRecord(writer, (SchEllipse)ellipse, ref index, ownerIndex);
@@ -498,16 +498,16 @@ public sealed class SchDocWriter
             SchLibWriter.WritePowerObjectRecord(writer, (SchPowerObject)powerObj, ref index);
 
         foreach (var polygon in document.Polygons)
-            SchLibWriter.WritePolygonRecord(writer, (SchPolygon)polygon, ref index, vertexUnits: SchLibWriter.CoordToDxpUnits);
+            SchLibWriter.WritePolygonRecord(writer, (SchPolygon)polygon, ref index);
 
         foreach (var polyline in document.Polylines)
-            SchLibWriter.WritePolylineRecord(writer, (SchPolyline)polyline, ref index, vertexUnits: SchLibWriter.CoordToDxpUnits);
+            SchLibWriter.WritePolylineRecord(writer, (SchPolyline)polyline, ref index);
 
         foreach (var arc in document.Arcs)
             SchLibWriter.WriteArcRecord(writer, (SchArc)arc, ref index);
 
         foreach (var bezier in document.Beziers)
-            SchLibWriter.WriteBezierRecord(writer, (SchBezier)bezier, ref index, vertexUnits: SchLibWriter.CoordToDxpUnits);
+            SchLibWriter.WriteBezierRecord(writer, (SchBezier)bezier, ref index);
 
         foreach (var ellipse in document.Ellipses)
             SchLibWriter.WriteEllipseRecord(writer, (SchEllipse)ellipse, ref index);
@@ -534,7 +534,7 @@ public sealed class SchDocWriter
             SchLibWriter.WriteNoErcRecord(writer, noErc, ref index);
 
         foreach (var bus in document.Buses)
-            SchLibWriter.WriteBusRecord(writer, bus, ref index, vertexUnits: SchLibWriter.CoordToDxpUnits);
+            SchLibWriter.WriteBusRecord(writer, bus, ref index);
 
         foreach (var busEntry in document.BusEntries)
             SchLibWriter.WriteBusEntryRecord(writer, busEntry, ref index);
@@ -564,7 +564,7 @@ public sealed class SchDocWriter
         foreach (var blanket in document.Blankets)
         {
             var blanketIndex = index;
-            SchLibWriter.WriteBlanketRecord(writer, blanket, ref index, vertexUnits: SchLibWriter.CoordToDxpUnits);
+            SchLibWriter.WriteBlanketRecord(writer, blanket, ref index);
             foreach (var param in blanket.Parameters)
                 SchLibWriter.WriteParameterRecord(writer, param, ref index, blanketIndex);
         }
@@ -710,8 +710,7 @@ public sealed class SchDocWriter
 
         for (var i = 0; i < wire.Vertices.Count; i++)
         {
-            parameters[$"X{i + 1}"] = SchLibWriter.CoordToDxpUnits(wire.Vertices[i].X);
-            parameters[$"Y{i + 1}"] = SchLibWriter.CoordToDxpUnits(wire.Vertices[i].Y);
+            SchLibWriter.AddSchVertex(parameters, i + 1, wire.Vertices[i].X, wire.Vertices[i].Y);
         }
 
         AddNonZero(parameters, "LINEWIDTH", wire.LineWidth);

--- a/src/OriginalCircuit.Altium/Serialization/Writers/SchLibWriter.cs
+++ b/src/OriginalCircuit.Altium/Serialization/Writers/SchLibWriter.cs
@@ -1672,16 +1672,15 @@ public sealed class SchLibWriter
     }
 
     /// <summary>
-    /// Converts a Coord to schematic units string (raw / 1000, i.e., 10 units per mil).
-    /// Used for vertex coordinates in polygon, polyline, and bezier records
-    /// where the reader's TryParseCoord() expects schematic units.
+    /// Converts a Coord to the DXP units used by SchLib vertex records
+    /// (raw / 100,000, i.e. one stored unit per 10 mils).
     /// </summary>
     internal static string CoordToSchematicUnits(Coord coord) =>
-        (coord.ToRaw() / 1000).ToString(CultureInfo.InvariantCulture);
+        (coord.ToRaw() / 100_000).ToString(CultureInfo.InvariantCulture);
 
     /// <summary>
-    /// Converts a Coord to whole DXP units (raw / 100,000, i.e. 10 mils per unit). SchDoc vertex
-    /// coordinates use this scale — unlike SchLib vertices, which use <see cref="CoordToSchematicUnits"/>.
+    /// Converts a Coord to whole DXP units (raw / 100,000, i.e. 10 mils per unit).
+    /// SchDoc and SchLib vertex records use this same scale.
     /// </summary>
     internal static string CoordToDxpUnits(Coord coord) =>
         (coord.ToRaw() / 100_000).ToString(CultureInfo.InvariantCulture);
@@ -1689,7 +1688,7 @@ public sealed class SchLibWriter
     /// <summary>
     /// Writes a vertex's X{n}/Y{n} parameters, omitting either when its value is 0
     /// (Altium does not emit zero-valued vertex coordinates). The vertex unit converter defaults to
-    /// SchLib schematic units; SchDoc callers pass <see cref="CoordToDxpUnits"/>.
+    /// SchLib DXP units; SchDoc callers pass <see cref="CoordToDxpUnits"/> explicitly.
     /// </summary>
     private static void AddSchVertex(Dictionary<string, string> parameters, int index, Coord x, Coord y,
         Func<Coord, string>? toUnits = null)

--- a/src/OriginalCircuit.Altium/Serialization/Writers/SchLibWriter.cs
+++ b/src/OriginalCircuit.Altium/Serialization/Writers/SchLibWriter.cs
@@ -681,8 +681,7 @@ public sealed class SchLibWriter
         index++;
     }
 
-    internal static void WritePolygonRecord(BinaryFormatWriter writer, SchPolygon polygon, ref int index, int ownerIndex = -1,
-        Func<Coord, string>? vertexUnits = null)
+    internal static void WritePolygonRecord(BinaryFormatWriter writer, SchPolygon polygon, ref int index, int ownerIndex = -1)
     {
         var parameters = new Dictionary<string, string>
         {
@@ -703,7 +702,7 @@ public sealed class SchLibWriter
         for (var i = 0; i < polygon.Vertices.Count; i++)
         {
             var v = polygon.Vertices[i];
-            AddSchVertex(parameters, i + 1, v.X, v.Y, vertexUnits);
+            AddSchVertex(parameters, i + 1, v.X, v.Y);
         }
         AddUniqueId(parameters, polygon.UniqueId);
 
@@ -711,8 +710,7 @@ public sealed class SchLibWriter
         index++;
     }
 
-    internal static void WritePolylineRecord(BinaryFormatWriter writer, SchPolyline polyline, ref int index, int ownerIndex = -1,
-        Func<Coord, string>? vertexUnits = null)
+    internal static void WritePolylineRecord(BinaryFormatWriter writer, SchPolyline polyline, ref int index, int ownerIndex = -1)
     {
         var parameters = new Dictionary<string, string>
         {
@@ -739,7 +737,7 @@ public sealed class SchLibWriter
         for (var i = 0; i < polyline.Vertices.Count; i++)
         {
             var v = polyline.Vertices[i];
-            AddSchVertex(parameters, i + 1, v.X, v.Y, vertexUnits);
+            AddSchVertex(parameters, i + 1, v.X, v.Y);
         }
         AddNonZero(parameters, "LineStyleExt", (int)polyline.LineStyle); // LineStyleExt follows the vertices
         AddUniqueId(parameters, polyline.UniqueId);
@@ -748,8 +746,7 @@ public sealed class SchLibWriter
         index++;
     }
 
-    internal static void WriteBezierRecord(BinaryFormatWriter writer, SchBezier bezier, ref int index, int ownerIndex = -1,
-        Func<Coord, string>? vertexUnits = null)
+    internal static void WriteBezierRecord(BinaryFormatWriter writer, SchBezier bezier, ref int index, int ownerIndex = -1)
     {
         var parameters = new Dictionary<string, string>
         {
@@ -768,7 +765,7 @@ public sealed class SchLibWriter
         for (var i = 0; i < bezier.ControlPoints.Count; i++)
         {
             var cp = bezier.ControlPoints[i];
-            AddSchVertex(parameters, i + 1, cp.X, cp.Y, vertexUnits);
+            AddSchVertex(parameters, i + 1, cp.X, cp.Y);
         }
         AddUniqueId(parameters, bezier.UniqueId);
 
@@ -962,8 +959,7 @@ public sealed class SchLibWriter
 
         for (var i = 0; i < wire.Vertices.Count; i++)
         {
-            parameters[$"X{i + 1}"] = CoordToSchematicUnits(wire.Vertices[i].X);
-            parameters[$"Y{i + 1}"] = CoordToSchematicUnits(wire.Vertices[i].Y);
+            AddSchVertex(parameters, i + 1, wire.Vertices[i].X, wire.Vertices[i].Y);
         }
 
         AddNonZero(parameters, "Color", wire.Color);
@@ -1184,8 +1180,7 @@ public sealed class SchLibWriter
         index++;
     }
 
-    internal static void WriteBusRecord(BinaryFormatWriter writer, SchBus bus, ref int index, int ownerIndex = -1,
-        Func<Coord, string>? vertexUnits = null)
+    internal static void WriteBusRecord(BinaryFormatWriter writer, SchBus bus, ref int index, int ownerIndex = -1)
     {
         var parameters = new Dictionary<string, string>
         {
@@ -1201,11 +1196,9 @@ public sealed class SchLibWriter
         AddNonZero(parameters, "Color", bus.Color);
         AddNonZero(parameters, "AreaColor", bus.AreaColor);
         parameters["LocationCount"] = bus.Vertices.Count.ToString(CultureInfo.InvariantCulture);
-        var busConv = vertexUnits ?? CoordToSchematicUnits;
         for (var i = 0; i < bus.Vertices.Count; i++)
         {
-            parameters[$"X{i + 1}"] = busConv(bus.Vertices[i].X);
-            parameters[$"Y{i + 1}"] = busConv(bus.Vertices[i].Y);
+            AddSchVertex(parameters, i + 1, bus.Vertices[i].X, bus.Vertices[i].Y);
         }
         AddUniqueId(parameters, bus.UniqueId);
 
@@ -1383,8 +1376,7 @@ public sealed class SchLibWriter
         index++;
     }
 
-    internal static void WriteBlanketRecord(BinaryFormatWriter writer, SchBlanket blanket, ref int index, int ownerIndex = -1,
-        Func<Coord, string>? vertexUnits = null)
+    internal static void WriteBlanketRecord(BinaryFormatWriter writer, SchBlanket blanket, ref int index, int ownerIndex = -1)
     {
         var parameters = new Dictionary<string, string>
         {
@@ -1403,11 +1395,9 @@ public sealed class SchLibWriter
         AddNonZero(parameters, "Color", blanket.Color);
         AddNonZero(parameters, "AreaColor", blanket.AreaColor);
         parameters["LocationCount"] = blanket.Vertices.Count.ToString(CultureInfo.InvariantCulture);
-        var blanketConv = vertexUnits ?? CoordToSchematicUnits;
         for (var i = 0; i < blanket.Vertices.Count; i++)
         {
-            parameters[$"X{i + 1}"] = blanketConv(blanket.Vertices[i].X);
-            parameters[$"Y{i + 1}"] = blanketConv(blanket.Vertices[i].Y);
+            AddSchVertex(parameters, i + 1, blanket.Vertices[i].X, blanket.Vertices[i].Y);
         }
         AddUniqueId(parameters, blanket.UniqueId);
 
@@ -1672,30 +1662,22 @@ public sealed class SchLibWriter
     }
 
     /// <summary>
-    /// Converts a Coord to the DXP units used by SchLib vertex records
-    /// (raw / 100,000, i.e. one stored unit per 10 mils).
-    /// </summary>
-    internal static string CoordToSchematicUnits(Coord coord) =>
-        (coord.ToRaw() / 100_000).ToString(CultureInfo.InvariantCulture);
-
-    /// <summary>
-    /// Converts a Coord to whole DXP units (raw / 100,000, i.e. 10 mils per unit).
-    /// SchDoc and SchLib vertex records use this same scale.
+    /// Converts a Coord to whole DXP units (10 mils per unit) used by SchDoc and SchLib
+    /// vertex records. Coordinates outside the native 10-mil grid are rounded to the nearest
+    /// representable point, with midpoint values rounded away from zero.
     /// </summary>
     internal static string CoordToDxpUnits(Coord coord) =>
-        (coord.ToRaw() / 100_000).ToString(CultureInfo.InvariantCulture);
+        Math.Round(coord.ToRaw() / 100_000d, MidpointRounding.AwayFromZero)
+            .ToString(CultureInfo.InvariantCulture);
 
     /// <summary>
     /// Writes a vertex's X{n}/Y{n} parameters, omitting either when its value is 0
-    /// (Altium does not emit zero-valued vertex coordinates). The vertex unit converter defaults to
-    /// SchLib DXP units; SchDoc callers pass <see cref="CoordToDxpUnits"/> explicitly.
+    /// (Altium does not emit zero-valued vertex coordinates).
     /// </summary>
-    private static void AddSchVertex(Dictionary<string, string> parameters, int index, Coord x, Coord y,
-        Func<Coord, string>? toUnits = null)
+    internal static void AddSchVertex(Dictionary<string, string> parameters, int index, Coord x, Coord y)
     {
-        var conv = toUnits ?? CoordToSchematicUnits;
-        var sx = conv(x);
-        var sy = conv(y);
+        var sx = CoordToDxpUnits(x);
+        var sy = CoordToDxpUnits(y);
         if (sx != "0") parameters[$"X{index}"] = sx;
         if (sy != "0") parameters[$"Y{index}"] = sy;
     }

--- a/tests/OriginalCircuit.Altium.Tests/RoundTrip/SchLibRoundTripTests.cs
+++ b/tests/OriginalCircuit.Altium.Tests/RoundTrip/SchLibRoundTripTests.cs
@@ -251,6 +251,13 @@ public sealed class SchLibRoundTripTests
     }
 
     [Fact]
+    public void Polyline_WritesNativeTenMilDxpVertexUnits()
+    {
+        Assert.Equal("10", SchLibWriter.CoordToSchematicUnits(Coord.FromMils(100)));
+        Assert.Equal("-2", SchLibWriter.CoordToSchematicUnits(Coord.FromMils(-20)));
+    }
+
+    [Fact]
     public void Bezier_PreservesAllProperties()
     {
         var original = new SchLibrary();

--- a/tests/OriginalCircuit.Altium.Tests/RoundTrip/SchLibRoundTripTests.cs
+++ b/tests/OriginalCircuit.Altium.Tests/RoundTrip/SchLibRoundTripTests.cs
@@ -251,10 +251,33 @@ public sealed class SchLibRoundTripTests
     }
 
     [Fact]
-    public void Polyline_WritesNativeTenMilDxpVertexUnits()
+    public void Polyline_RoundTripUsesNativeTenMilDxpVertexUnits()
     {
-        Assert.Equal("10", SchLibWriter.CoordToSchematicUnits(Coord.FromMils(100)));
-        Assert.Equal("-2", SchLibWriter.CoordToSchematicUnits(Coord.FromMils(-20)));
+        var original = new SchLibrary();
+        var component = new SchComponent { Name = "DXP_GRID", PartCount = 1 };
+        component.AddPolyline(SchPolyline.Create()
+            .AddVertex(Coord.FromMils(-20), Coord.FromMils(50))
+            .AddVertex(Coord.FromMils(100), Coord.FromMils(-100))
+            .Build());
+        original.Add(component);
+
+        var readBack = RoundTrip(original);
+        var vertices = readBack.Components.Single().Polylines.Single().Vertices;
+
+        Assert.Equal(-20, vertices[0].X.ToMils(), 6);
+        Assert.Equal(50, vertices[0].Y.ToMils(), 6);
+        Assert.Equal(100, vertices[1].X.ToMils(), 6);
+        Assert.Equal(-100, vertices[1].Y.ToMils(), 6);
+    }
+
+    [Theory]
+    [InlineData(104, "10")]
+    [InlineData(105, "11")]
+    [InlineData(-104, "-10")]
+    [InlineData(-105, "-11")]
+    public void VertexCoordinatesOutsideTenMilGridRoundToNearestNativeUnit(double mils, string expected)
+    {
+        Assert.Equal(expected, SchLibWriter.CoordToDxpUnits(Coord.FromMils(mils)));
     }
 
     [Fact]


### PR DESCRIPTION
Correct SchLib vertex record scaling to native 10 mil DXP units. Targeted SchLib tests: 2 passed. Downstream Electronics.Altium tests: 50 passed. Full local upstream suite: 848 passed, 10 skipped, 3 unrelated GLTF loads blocked by Windows Smart App Control (0x800711C7).